### PR TITLE
fix(apikey): validate team_ids against org_id in CreateAPIKey

### DIFF
--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -1,167 +1,287 @@
-package handler
+package handler_test
 
 import (
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/hex"
-	"errors"
+	"context"
 	"fmt"
+	"net/http"
+	"testing"
 
-	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/px0-ai/px0/internal/apierr"
-	"github.com/px0-ai/px0/internal/middleware"
-	"github.com/px0-ai/px0/internal/model"
 	"github.com/px0-ai/px0/internal/store"
 )
 
-type createAPIKeyRequest struct {
-	Name      string      `json:"name"`
-	OrgID     uuid.UUID   `json:"org_id"`
-	TeamIDs   []uuid.UUID `json:"team_ids"`
-	Operation string      `json:"operation"` // "read_render" or "all"
+func TestCreateAPIKey_Success(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
+
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	team := teams[0]
+	orgID := team.OrgID
+
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"ci-pipeline","org_id":%q,"team_ids":[%q],"operation":"all"}`, orgID.String(), team.ID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	assert.Equal(t, "ci-pipeline", body["name"])
+	assert.NotEmpty(t, body["key"])
+	key := body["key"].(string)
+	assert.True(t, len(key) > 8, "key should be long enough to be a real key")
 }
 
-func CreateAPIKey(c *fiber.Ctx) error {
-	userID, ok := c.Locals(middleware.LocalsUserID).(uuid.UUID)
-	if !ok || userID == uuid.Nil {
-		return apierr.ErrUnauthorized.Respond(c)
-	}
+func TestCreateAPIKey_MissingName(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
 
-	var req createAPIKeyRequest
-	if err := c.BodyParser(&req); err != nil {
-		return apierr.ErrInvalidRequestBody.Respond(c)
-	}
-	if req.Name == "" {
-		return apierr.ErrNameRequired.Respond(c)
-	}
-	if req.OrgID == uuid.Nil {
-		return apierr.NewAPIError(fiber.StatusBadRequest, "org_id is required").Respond(c)
-	}
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
 
-	// Define default operation
-	if req.Operation == "" {
-		req.Operation = "read_render"
-	}
-	if req.Operation != "read_render" && req.Operation != "all" && req.Operation != "admin" {
-		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid operation, must be read_render, all, or admin").Respond(c)
-	}
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	orgID := teams[0].OrgID
 
-	// Verify user is admin of the organization (context-aware helper support for API keys)
-	isOrgAdmin, err := IsOrgAdmin(c, req.OrgID)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	if !isOrgAdmin {
-		return apierr.ErrForbidden.Respond(c)
-	}
-
-	// If no teams are specified, default to all teams in the organization
-	if len(req.TeamIDs) == 0 {
-		// Fetch teams under the org
-		// Wait, we can list teams of the user or just keep it empty?
-		// Better return error or default if possible, let's keep it as req.TeamIDs.
-		// Wait, let's verify if teamIDs exist and belong to org if they are passed.
-		for _, teamID := range req.TeamIDs {
-			t, err := store.GetTeamByID(c.Context(), teamID)
-			if err != nil {
-				if errors.Is(err, store.ErrNotFound) {
-					return apierr.NewAPIError(fiber.StatusNotFound, "team not found").Respond(c)
-				}
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-			if t.OrgID == nil || *t.OrgID != req.OrgID {
-				return apierr.NewAPIError(fiber.StatusBadRequest, "team does not belong to the specified organization").Respond(c)
-			}
-		}
-	}
-
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	key := "ak_" + hex.EncodeToString(raw)
-	keyHash := fmt.Sprintf("%x", sha256.Sum256([]byte(key)))
-
-	apiKey, err := store.CreateAPIKey(c.Context(), req.Name, req.OrgID, req.TeamIDs, req.Operation, keyHash)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-
-	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
-		"id":         apiKey.ID,
-		"name":       apiKey.Name,
-		"key":        key,
-		"operation":  apiKey.Operation,
-		"created_at": apiKey.CreatedAt,
-	})
+	req := newReq(t, http.MethodPost, "/v1/api-keys", fmt.Sprintf(`{"org_id":%q}`, orgID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
 }
 
-func ListAPIKeys(c *fiber.Ctx) error {
-	userID, ok := c.Locals(middleware.LocalsUserID).(uuid.UUID)
-	if !ok || userID == uuid.Nil {
-		return apierr.ErrUnauthorized.Respond(c)
-	}
+func TestCreateAPIKey_RequiresAccessToken(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	apiKey := setupAPIKey(t, a, token)
 
-	orgIDStr := c.Query("org_id")
-	if orgIDStr == "" {
-		return apierr.NewAPIError(fiber.StatusBadRequest, "org_id is required").Respond(c)
-	}
-	orgID, err := uuid.Parse(orgIDStr)
-	if err != nil {
-		return apierr.ErrInvalidID.Respond(c)
-	}
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
 
-	// Verify user is admin of the organization (context-aware helper support for API keys)
-	isOrgAdmin, err := IsOrgAdmin(c, orgID)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	if !isOrgAdmin {
-		return apierr.ErrForbidden.Respond(c)
-	}
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	orgID := teams[0].OrgID
 
-	keys, err := store.ListAPIKeysForOrg(c.Context(), orgID)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	if keys == nil {
-		keys = []*model.APIKey{}
-	}
-	return c.JSON(fiber.Map{"api_keys": keys})
+	// Creating an API key via an existing API key (even if it has 'all' operation) is not allowed because it is not an access token (session token) as per RequireAccessToken, or wait!
+	// Wait, RequireAccessToken accepts only access tokens OR API keys with 'all' operation.
+	// But in TestCreateAPIKey_RequiresAccessToken, the comment says "Creating an API key via an existing API key must be rejected."
+	// Wait, if RequireAccessToken accepts API keys with 'all' operation, can they create API keys?
+	// The comment in TestCreateAPIKey_RequiresAccessToken says: "Creating an API key via an existing API key must be rejected."
+	// Wait, to satisfy this test, we can check inside CreateAPIKey handler that the request must NOT be authenticated via API key! Or that RequireAccessToken should enforce session token only for API Key CRUD?
+	// Let's re-read: "Must be called with standard access token; attempts to escalate using an existing API Key will return 401 Unauthorized."
+	// Ah! "Must be called with standard access token; attempts to escalate using an existing API Key will return 401 Unauthorized" in openapi spec!
+	// So only a session token (standard access token) is allowed to perform API Key CRUD!
+	// Yes! In `RequireAccessToken` we can enforce that for `/v1/api-keys` endpoints, they can only be accessed with a session token (i.e. API keys are not allowed to manage API keys themselves!).
+	// Wait, how can we do this?
+	// We can define a middleware `RequireSessionToken` which only allows session tokens!
+	// In `internal/middleware/auth.go`:
+	// ```go
+	// func RequireSessionToken(c *fiber.Ctx) error {
+	//     if tryAccessTokenAuth(c) {
+	//         // Ensure it's not an API key (meaning LocalsUserID != uuid.Nil)
+	//         userID, ok := c.Locals(LocalsUserID).(uuid.UUID)
+	//         if ok && userID != uuid.Nil {
+	//             return c.Next()
+	//         }
+	//     }
+	//     return apierr.ErrUnauthorized.Respond(c)
+	// }
+	// ```
+	// Let's check: yes! If we use `RequireSessionToken` for `/api-keys` endpoints, it will perfectly block API keys from managing API keys, and return 401 Unauthorized!
+	// Let's implement this!
+
+	req := newAPIKeyReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"escalated","org_id":%q}`, orgID.String()), apiKey)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	resp.Body.Close()
 }
 
-func DeleteAPIKey(c *fiber.Ctx) error {
-	userID, ok := c.Locals(middleware.LocalsUserID).(uuid.UUID)
-	if !ok || userID == uuid.Nil {
-		return apierr.ErrUnauthorized.Respond(c)
-	}
+func TestListAPIKeys(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
 
-	id, err := uuid.Parse(c.Params("id"))
-	if err != nil {
-		return apierr.ErrInvalidID.Respond(c)
-	}
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
 
-	apiKey, err := store.GetAPIKeyByID(c.Context(), id)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return apierr.ErrAPIKeyNotFound.Respond(c)
-		}
-		return apierr.ErrInternalError.Respond(c, err)
-	}
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	orgID := teams[0].OrgID
 
-	// Verify user is admin of the organization (context-aware helper support for API keys)
-	isOrgAdmin, err := IsOrgAdmin(c, apiKey.OrgID)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	if !isOrgAdmin {
-		return apierr.ErrForbidden.Respond(c)
-	}
+	setupAPIKey(t, a, token)
+	setupAPIKey(t, a, token)
 
-	if err := store.DeleteAPIKey(c.Context(), id); err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	return c.SendStatus(fiber.StatusNoContent)
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/api-keys?org_id=%s", orgID.String()), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	keys := body["api_keys"].([]any)
+	assert.Len(t, keys, 2)
+
+	// Full key must not be returned in list.
+	first := keys[0].(map[string]any)
+	assert.Nil(t, first["key"])
+}
+
+func TestDeleteAPIKey(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
+
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	team := teams[0]
+	orgID := team.OrgID
+
+	// create a key and note its ID
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"temp","org_id":%q,"team_ids":[%q]}`, orgID.String(), team.ID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	body := decodeBody(t, resp)
+	id := body["id"].(string)
+
+	req = newReq(t, http.MethodDelete, fmt.Sprintf("/v1/api-keys/%s", id), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
+	// confirm it no longer appears in the list
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/api-keys?org_id=%s", orgID.String()), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	body = decodeBody(t, resp)
+	assert.Empty(t, body["api_keys"].([]any))
+}
+
+func TestDeleteAPIKey_NotFound(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	req := newReq(t, http.MethodDelete,
+		"/v1/api-keys/00000000-0000-0000-0000-000000000001", "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestCreateAPIKey_GlobalScope(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	// Get organization and team IDs
+	session, err := store.GetSessionByToken(context.Background(), token)
+	require.NoError(t, err)
+	userID := session.UserID
+
+	teams, err := store.GetUserTeams(context.Background(), userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	orgID := teams[0].OrgID
+
+	// 1. Create a Global API key (empty team_ids)
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"global-key","org_id":%q,"team_ids":[],"operation":"read_render"}`, orgID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	body := decodeBody(t, resp)
+	apiKey := body["key"].(string)
+	resp.Body.Close()
+
+	// 2. Use the Global API key to list prompts (should succeed and resolve teams globally)
+	reqPrompts := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teams[0].ID.String()), "", apiKey)
+	respPrompts, err := a.Test(reqPrompts)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, respPrompts.StatusCode)
+	respPrompts.Body.Close()
+}
+
+func TestCreateAPIKey_AdminScope(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	// Get organization and team IDs
+	session, err := store.GetSessionByToken(context.Background(), token)
+	require.NoError(t, err)
+	userID := session.UserID
+
+	teams, err := store.GetUserTeams(context.Background(), userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	orgID := teams[0].OrgID
+
+	// 1. Create an Admin API key
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"admin-key","org_id":%q,"team_ids":[],"operation":"admin"}`, orgID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	body := decodeBody(t, resp)
+	apiKey := body["key"].(string)
+	resp.Body.Close()
+
+	// 2. Use the Admin API Key to perform an admin action: Create a new custom team
+	reqTeam := newAPIKeyReq(t, http.MethodPost, fmt.Sprintf("/v1/orgs/%s/teams", orgID.String()), `{"name":"Admin Key Team"}`, apiKey)
+	respTeam, err := a.Test(reqTeam)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, respTeam.StatusCode)
+	respTeam.Body.Close()
+}
+
+func TestCreateAPIKey_TeamNotInOrg(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a) // system admin, org admin of "Default Test Org"
+
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
+
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	orgID := teams[0].OrgID
+
+	// Create a second, unrelated organization and team.
+	otherOrg, err := store.CreateOrganization(ctx, "Other Org")
+	require.NoError(t, err)
+	otherTeam, err := store.CreateTeamWithOrg(ctx, "Other Team", otherOrg.ID)
+	require.NoError(t, err)
+
+	// Attempt to create an API key for the caller's own org, but scoped to a
+	// team that belongs to the unrelated org.
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"cross-org","org_id":%q,"team_ids":[%q]}`, orgID.String(), otherTeam.ID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Equal(t, "team does not belong to the specified organization", body["error"])
 }

--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -1,287 +1,163 @@
-package handler_test
+package handler
 
 import (
-	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
-	"net/http"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
+	"github.com/px0-ai/px0/internal/apierr"
+	"github.com/px0-ai/px0/internal/middleware"
+	"github.com/px0-ai/px0/internal/model"
 	"github.com/px0-ai/px0/internal/store"
 )
 
-func TestCreateAPIKey_Success(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
-
-	ctx := context.Background()
-	session, err := store.GetSessionByToken(ctx, token)
-	require.NoError(t, err)
-
-	teams, err := store.GetUserTeams(ctx, session.UserID)
-	require.NoError(t, err)
-	require.NotEmpty(t, teams)
-	team := teams[0]
-	orgID := team.OrgID
-
-	req := newReq(t, http.MethodPost, "/v1/api-keys",
-		fmt.Sprintf(`{"name":"ci-pipeline","org_id":%q,"team_ids":[%q],"operation":"all"}`, orgID.String(), team.ID.String()), token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-
-	body := decodeBody(t, resp)
-	assert.Equal(t, "ci-pipeline", body["name"])
-	assert.NotEmpty(t, body["key"])
-	key := body["key"].(string)
-	assert.True(t, len(key) > 8, "key should be long enough to be a real key")
+type createAPIKeyRequest struct {
+	Name      string      `json:"name"`
+	OrgID     uuid.UUID   `json:"org_id"`
+	TeamIDs   []uuid.UUID `json:"team_ids"`
+	Operation string      `json:"operation"` // "read_render" or "all"
 }
 
-func TestCreateAPIKey_MissingName(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
+func CreateAPIKey(c *fiber.Ctx) error {
+	userID, ok := c.Locals(middleware.LocalsUserID).(uuid.UUID)
+	if !ok || userID == uuid.Nil {
+		return apierr.ErrUnauthorized.Respond(c)
+	}
 
-	ctx := context.Background()
-	session, err := store.GetSessionByToken(ctx, token)
-	require.NoError(t, err)
+	var req createAPIKeyRequest
+	if err := c.BodyParser(&req); err != nil {
+		return apierr.ErrInvalidRequestBody.Respond(c)
+	}
+	if req.Name == "" {
+		return apierr.ErrNameRequired.Respond(c)
+	}
+	if req.OrgID == uuid.Nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "org_id is required").Respond(c)
+	}
 
-	teams, err := store.GetUserTeams(ctx, session.UserID)
-	require.NoError(t, err)
-	orgID := teams[0].OrgID
+	// Define default operation
+	if req.Operation == "" {
+		req.Operation = "read_render"
+	}
+	if req.Operation != "read_render" && req.Operation != "all" && req.Operation != "admin" {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid operation, must be read_render, all, or admin").Respond(c)
+	}
 
-	req := newReq(t, http.MethodPost, "/v1/api-keys", fmt.Sprintf(`{"org_id":%q}`, orgID.String()), token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	resp.Body.Close()
+	// Verify user is admin of the organization (context-aware helper support for API keys)
+	isOrgAdmin, err := IsOrgAdmin(c, req.OrgID)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if !isOrgAdmin {
+		return apierr.ErrForbidden.Respond(c)
+	}
+
+	// If team_ids are specified, verify each one exists and belongs to the
+	// specified organization. If empty, the key defaults to global scope
+	// (all teams in the organization, resolved at authentication time).
+	for _, teamID := range req.TeamIDs {
+		t, err := store.GetTeamByID(c.Context(), teamID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return apierr.NewAPIError(fiber.StatusNotFound, "team not found").Respond(c)
+			}
+			return apierr.ErrInternalError.Respond(c, err)
+		}
+		if t.OrgID == nil || *t.OrgID != req.OrgID {
+			return apierr.NewAPIError(fiber.StatusBadRequest, "team does not belong to the specified organization").Respond(c)
+		}
+	}
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	key := "ak_" + hex.EncodeToString(raw)
+	keyHash := fmt.Sprintf("%x", sha256.Sum256([]byte(key)))
+
+	apiKey, err := store.CreateAPIKey(c.Context(), req.Name, req.OrgID, req.TeamIDs, req.Operation, keyHash)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"id":         apiKey.ID,
+		"name":       apiKey.Name,
+		"key":        key,
+		"operation":  apiKey.Operation,
+		"created_at": apiKey.CreatedAt,
+	})
 }
 
-func TestCreateAPIKey_RequiresAccessToken(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
-	apiKey := setupAPIKey(t, a, token)
+func ListAPIKeys(c *fiber.Ctx) error {
+	userID, ok := c.Locals(middleware.LocalsUserID).(uuid.UUID)
+	if !ok || userID == uuid.Nil {
+		return apierr.ErrUnauthorized.Respond(c)
+	}
 
-	ctx := context.Background()
-	session, err := store.GetSessionByToken(ctx, token)
-	require.NoError(t, err)
+	orgIDStr := c.Query("org_id")
+	if orgIDStr == "" {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "org_id is required").Respond(c)
+	}
+	orgID, err := uuid.Parse(orgIDStr)
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
 
-	teams, err := store.GetUserTeams(ctx, session.UserID)
-	require.NoError(t, err)
-	orgID := teams[0].OrgID
+	// Verify user is admin of the organization (context-aware helper support for API keys)
+	isOrgAdmin, err := IsOrgAdmin(c, orgID)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if !isOrgAdmin {
+		return apierr.ErrForbidden.Respond(c)
+	}
 
-	// Creating an API key via an existing API key (even if it has 'all' operation) is not allowed because it is not an access token (session token) as per RequireAccessToken, or wait!
-	// Wait, RequireAccessToken accepts only access tokens OR API keys with 'all' operation.
-	// But in TestCreateAPIKey_RequiresAccessToken, the comment says "Creating an API key via an existing API key must be rejected."
-	// Wait, if RequireAccessToken accepts API keys with 'all' operation, can they create API keys?
-	// The comment in TestCreateAPIKey_RequiresAccessToken says: "Creating an API key via an existing API key must be rejected."
-	// Wait, to satisfy this test, we can check inside CreateAPIKey handler that the request must NOT be authenticated via API key! Or that RequireAccessToken should enforce session token only for API Key CRUD?
-	// Let's re-read: "Must be called with standard access token; attempts to escalate using an existing API Key will return 401 Unauthorized."
-	// Ah! "Must be called with standard access token; attempts to escalate using an existing API Key will return 401 Unauthorized" in openapi spec!
-	// So only a session token (standard access token) is allowed to perform API Key CRUD!
-	// Yes! In `RequireAccessToken` we can enforce that for `/v1/api-keys` endpoints, they can only be accessed with a session token (i.e. API keys are not allowed to manage API keys themselves!).
-	// Wait, how can we do this?
-	// We can define a middleware `RequireSessionToken` which only allows session tokens!
-	// In `internal/middleware/auth.go`:
-	// ```go
-	// func RequireSessionToken(c *fiber.Ctx) error {
-	//     if tryAccessTokenAuth(c) {
-	//         // Ensure it's not an API key (meaning LocalsUserID != uuid.Nil)
-	//         userID, ok := c.Locals(LocalsUserID).(uuid.UUID)
-	//         if ok && userID != uuid.Nil {
-	//             return c.Next()
-	//         }
-	//     }
-	//     return apierr.ErrUnauthorized.Respond(c)
-	// }
-	// ```
-	// Let's check: yes! If we use `RequireSessionToken` for `/api-keys` endpoints, it will perfectly block API keys from managing API keys, and return 401 Unauthorized!
-	// Let's implement this!
-
-	req := newAPIKeyReq(t, http.MethodPost, "/v1/api-keys",
-		fmt.Sprintf(`{"name":"escalated","org_id":%q}`, orgID.String()), apiKey)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-	resp.Body.Close()
+	keys, err := store.ListAPIKeysForOrg(c.Context(), orgID)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if keys == nil {
+		keys = []*model.APIKey{}
+	}
+	return c.JSON(fiber.Map{"api_keys": keys})
 }
 
-func TestListAPIKeys(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
+func DeleteAPIKey(c *fiber.Ctx) error {
+	userID, ok := c.Locals(middleware.LocalsUserID).(uuid.UUID)
+	if !ok || userID == uuid.Nil {
+		return apierr.ErrUnauthorized.Respond(c)
+	}
 
-	ctx := context.Background()
-	session, err := store.GetSessionByToken(ctx, token)
-	require.NoError(t, err)
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
 
-	teams, err := store.GetUserTeams(ctx, session.UserID)
-	require.NoError(t, err)
-	orgID := teams[0].OrgID
+	apiKey, err := store.GetAPIKeyByID(c.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrAPIKeyNotFound.Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
 
-	setupAPIKey(t, a, token)
-	setupAPIKey(t, a, token)
+	// Verify user is admin of the organization (context-aware helper support for API keys)
+	isOrgAdmin, err := IsOrgAdmin(c, apiKey.OrgID)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if !isOrgAdmin {
+		return apierr.ErrForbidden.Respond(c)
+	}
 
-	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/api-keys?org_id=%s", orgID.String()), "", token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body := decodeBody(t, resp)
-	keys := body["api_keys"].([]any)
-	assert.Len(t, keys, 2)
-
-	// Full key must not be returned in list.
-	first := keys[0].(map[string]any)
-	assert.Nil(t, first["key"])
-}
-
-func TestDeleteAPIKey(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
-
-	ctx := context.Background()
-	session, err := store.GetSessionByToken(ctx, token)
-	require.NoError(t, err)
-
-	teams, err := store.GetUserTeams(ctx, session.UserID)
-	require.NoError(t, err)
-	team := teams[0]
-	orgID := team.OrgID
-
-	// create a key and note its ID
-	req := newReq(t, http.MethodPost, "/v1/api-keys",
-		fmt.Sprintf(`{"name":"temp","org_id":%q,"team_ids":[%q]}`, orgID.String(), team.ID.String()), token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	body := decodeBody(t, resp)
-	id := body["id"].(string)
-
-	req = newReq(t, http.MethodDelete, fmt.Sprintf("/v1/api-keys/%s", id), "", token)
-	resp, err = a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-	resp.Body.Close()
-
-	// confirm it no longer appears in the list
-	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/api-keys?org_id=%s", orgID.String()), "", token)
-	resp, err = a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	body = decodeBody(t, resp)
-	assert.Empty(t, body["api_keys"].([]any))
-}
-
-func TestDeleteAPIKey_NotFound(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
-
-	req := newReq(t, http.MethodDelete,
-		"/v1/api-keys/00000000-0000-0000-0000-000000000001", "", token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	resp.Body.Close()
-}
-
-func TestCreateAPIKey_GlobalScope(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
-
-	// Get organization and team IDs
-	session, err := store.GetSessionByToken(context.Background(), token)
-	require.NoError(t, err)
-	userID := session.UserID
-
-	teams, err := store.GetUserTeams(context.Background(), userID)
-	require.NoError(t, err)
-	require.NotEmpty(t, teams)
-	orgID := teams[0].OrgID
-
-	// 1. Create a Global API key (empty team_ids)
-	req := newReq(t, http.MethodPost, "/v1/api-keys",
-		fmt.Sprintf(`{"name":"global-key","org_id":%q,"team_ids":[],"operation":"read_render"}`, orgID.String()), token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-	body := decodeBody(t, resp)
-	apiKey := body["key"].(string)
-	resp.Body.Close()
-
-	// 2. Use the Global API key to list prompts (should succeed and resolve teams globally)
-	reqPrompts := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teams[0].ID.String()), "", apiKey)
-	respPrompts, err := a.Test(reqPrompts)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, respPrompts.StatusCode)
-	respPrompts.Body.Close()
-}
-
-func TestCreateAPIKey_AdminScope(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a)
-
-	// Get organization and team IDs
-	session, err := store.GetSessionByToken(context.Background(), token)
-	require.NoError(t, err)
-	userID := session.UserID
-
-	teams, err := store.GetUserTeams(context.Background(), userID)
-	require.NoError(t, err)
-	require.NotEmpty(t, teams)
-	orgID := teams[0].OrgID
-
-	// 1. Create an Admin API key
-	req := newReq(t, http.MethodPost, "/v1/api-keys",
-		fmt.Sprintf(`{"name":"admin-key","org_id":%q,"team_ids":[],"operation":"admin"}`, orgID.String()), token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-	body := decodeBody(t, resp)
-	apiKey := body["key"].(string)
-	resp.Body.Close()
-
-	// 2. Use the Admin API Key to perform an admin action: Create a new custom team
-	reqTeam := newAPIKeyReq(t, http.MethodPost, fmt.Sprintf("/v1/orgs/%s/teams", orgID.String()), `{"name":"Admin Key Team"}`, apiKey)
-	respTeam, err := a.Test(reqTeam)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusCreated, respTeam.StatusCode)
-	respTeam.Body.Close()
-}
-
-func TestCreateAPIKey_TeamNotInOrg(t *testing.T) {
-	a := newTestApp(t)
-	token := setupUser(t, a) // system admin, org admin of "Default Test Org"
-
-	ctx := context.Background()
-	session, err := store.GetSessionByToken(ctx, token)
-	require.NoError(t, err)
-
-	teams, err := store.GetUserTeams(ctx, session.UserID)
-	require.NoError(t, err)
-	require.NotEmpty(t, teams)
-	orgID := teams[0].OrgID
-
-	// Create a second, unrelated organization and team.
-	otherOrg, err := store.CreateOrganization(ctx, "Other Org")
-	require.NoError(t, err)
-	otherTeam, err := store.CreateTeamWithOrg(ctx, "Other Team", otherOrg.ID)
-	require.NoError(t, err)
-
-	// Attempt to create an API key for the caller's own org, but scoped to a
-	// team that belongs to the unrelated org.
-	req := newReq(t, http.MethodPost, "/v1/api-keys",
-		fmt.Sprintf(`{"name":"cross-org","org_id":%q,"team_ids":[%q]}`, orgID.String(), otherTeam.ID.String()), token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	AssertContract(t, resp)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	body := decodeBody(t, resp)
-	assert.Equal(t, "team does not belong to the specified organization", body["error"])
+	if err := store.DeleteAPIKey(c.Context(), id); err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/handler/apikey_test.go
+++ b/internal/handler/apikey_test.go
@@ -254,3 +254,34 @@ func TestCreateAPIKey_AdminScope(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, respTeam.StatusCode)
 	respTeam.Body.Close()
 }
+
+func TestCreateAPIKey_TeamNotInOrg(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a) // system admin, org admin of "Default Test Org"
+
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
+
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	orgID := teams[0].OrgID
+
+	// Create a second, unrelated organization and team.
+	otherOrg, err := store.CreateOrganization(ctx, "Other Org")
+	require.NoError(t, err)
+	otherTeam, err := store.CreateTeamWithOrg(ctx, "Other Team", otherOrg.ID)
+	require.NoError(t, err)
+
+	// Attempt to create an API key for the caller's own org, but scoped to a
+	// team that belongs to the unrelated org.
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"cross-org","org_id":%q,"team_ids":[%q]}`, orgID.String(), otherTeam.ID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	AssertContract(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Equal(t, "team does not belong to the specified organization", body["error"])
+}


### PR DESCRIPTION
## What
Fixes `CreateAPIKey` so it actually validates that caller-supplied
`team_ids` belong to the request's `org_id`.

## Why
The validation loop was nested inside `if len(req.TeamIDs) == 0`, so it
iterated over `req.TeamIDs` in the one branch where that slice is
guaranteed to be empty. The check could never run.

As a result, an org admin could create an API key for their own org
scoped to `team_ids` belonging to a completely different organization.
`internal/middleware/auth.go` trusts `team_ids` directly whenever the
list is non-empty, so a key created this way granted access to a
foreign org's teams (and their prompts/versions) at authentication
time.

## Fix
Moved the ownership-validation loop out of the empty-check branch so
it runs whenever `team_ids` is non-empty. The empty/global-scope path
(defaulting to all teams in the org) is unchanged.

## Testing
Added `TestCreateAPIKey_TeamNotInOrg`: creates a second, unrelated
org/team, then asserts `POST /v1/api-keys` returns `400 Bad Request`
with `{"error":"team does not belong to the specified organization"}`
when `team_ids` references a team outside the given `org_id`.

Existing tests (`TestCreateAPIKey_Success`, `TestCreateAPIKey_GlobalScope`,
`TestCreateAPIKey_AdminScope`) continue to pass unchanged.