### PR TITLE
Validate API key team scopes against their organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for taking the time to improve px0. Keep changes focused, tested, and easy to review.
+
+## Before opening a pull request
+
+- Keep the pull request scoped to one fix or feature.
+- Add or update tests for every behavior change.
+- Update the OpenAPI files under `docs/openapi/` when API behavior, validation, or response shapes change.
+- Regenerate the bundled OpenAPI file after spec changes:
+
+```bash
+make spec-bundle
+```
+
+- Run the project checks before pushing:
+
+```bash
+make test
+make check
+```
+
+Integration tests skip automatically when the local test database is unavailable.
+
+## Commit messages
+
+Use the `ape-commit` skill from [arpitbbhayani/ape-skills](https://github.com/arpitbbhayani/ape-skills/tree/master/ape-commit) before pushing commits.
+
+Install it with:
+
+```bash
+npx skills add https://github.com/arpitbbhayani/ape-skills/tree/master/ape-commit
+```
+
+Commit messages should follow this format:
+
+```text
+<short imperative summary>
+
+- <imperative change>
+- <imperative change>
+- <imperative change>
+```
+
+Guidelines:
+
+- Keep the summary short, specific, and under 72 characters.
+- Use imperative mood, such as `Fix API key validation`, not `Fixed` or `Fixes`.
+- Leave one blank line between the summary and bullets.
+- Keep each bullet to one concrete change.
+- Do not include generated-by or co-author attribution lines.

--- a/docs/openapi/api-keys.yaml
+++ b/docs/openapi/api-keys.yaml
@@ -14,6 +14,18 @@ paths:
         - API Keys
       security:
         - BearerAuth: []
+      x-edge-cases:
+        - "Only standard user session tokens can create API keys; existing API keys cannot create or rotate other keys."
+        - "If team_ids is omitted or empty, the key is scoped to all teams in the organization."
+        - "Every supplied team_id must exist and belong to the specified org_id."
+      x-test-coverage:
+        - "TestCreateAPIKey_Success: Verifies key creation with an explicit team scope."
+        - "TestCreateAPIKey_MissingName: Verifies missing key name returns 400."
+        - "TestCreateAPIKey_RequiresAccessToken: Verifies API keys cannot create other API keys."
+        - "TestCreateAPIKey_GlobalScope: Verifies empty team_ids creates an org-wide key."
+        - "TestCreateAPIKey_AdminScope: Verifies admin operation keys can perform authorized admin actions."
+        - "TestCreateAPIKey_RejectsTeamOutsideOrg: Verifies teams from another organization are rejected."
+        - "TestCreateAPIKey_RejectsUnknownTeam: Verifies unknown team IDs are rejected."
       requestBody:
         required: true
         content:
@@ -41,6 +53,12 @@ paths:
                 $ref: "./auth.yaml#/components/schemas/APIError"
         "403":
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Referenced team not found
           content:
             application/json:
               schema:
@@ -171,8 +189,10 @@ components:
         org_id:
           type: string
           format: uuid
+          description: Organization that owns the API key.
         team_ids:
           type: array
+          description: Optional list of teams the key can access. Omit or pass an empty array for organization-wide access.
           items:
             type: string
             format: uuid

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -636,6 +636,18 @@ paths:
         - API Keys
       security:
         - BearerAuth: []
+      x-edge-cases:
+        - Only standard user session tokens can create API keys; existing API keys cannot create or rotate other keys.
+        - If team_ids is omitted or empty, the key is scoped to all teams in the organization.
+        - Every supplied team_id must exist and belong to the specified org_id.
+      x-test-coverage:
+        - 'TestCreateAPIKey_Success: Verifies key creation with an explicit team scope.'
+        - 'TestCreateAPIKey_MissingName: Verifies missing key name returns 400.'
+        - 'TestCreateAPIKey_RequiresAccessToken: Verifies API keys cannot create other API keys.'
+        - 'TestCreateAPIKey_GlobalScope: Verifies empty team_ids creates an org-wide key.'
+        - 'TestCreateAPIKey_AdminScope: Verifies admin operation keys can perform authorized admin actions.'
+        - 'TestCreateAPIKey_RejectsTeamOutsideOrg: Verifies teams from another organization are rejected.'
+        - 'TestCreateAPIKey_RejectsUnknownTeam: Verifies unknown team IDs are rejected.'
       requestBody:
         required: true
         content:
@@ -663,6 +675,12 @@ paths:
                 $ref: '#/components/schemas/APIError'
         '403':
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Referenced team not found
           content:
             application/json:
               schema:
@@ -3958,8 +3976,10 @@ components:
         org_id:
           type: string
           format: uuid
+          description: Organization that owns the API key.
         team_ids:
           type: array
+          description: Optional list of teams the key can access. Omit or pass an empty array for organization-wide access.
           items:
             type: string
             format: uuid

--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -57,23 +57,18 @@ func CreateAPIKey(c *fiber.Ctx) error {
 		return apierr.ErrForbidden.Respond(c)
 	}
 
-	// If no teams are specified, default to all teams in the organization
-	if len(req.TeamIDs) == 0 {
-		// Fetch teams under the org
-		// Wait, we can list teams of the user or just keep it empty?
-		// Better return error or default if possible, let's keep it as req.TeamIDs.
-		// Wait, let's verify if teamIDs exist and belong to org if they are passed.
-		for _, teamID := range req.TeamIDs {
-			t, err := store.GetTeamByID(c.Context(), teamID)
-			if err != nil {
-				if errors.Is(err, store.ErrNotFound) {
-					return apierr.NewAPIError(fiber.StatusNotFound, "team not found").Respond(c)
-				}
-				return apierr.ErrInternalError.Respond(c, err)
+	// Empty team_ids intentionally creates an org-wide key. When teams are
+	// supplied, every team must exist and belong to the requested organization.
+	for _, teamID := range req.TeamIDs {
+		t, err := store.GetTeamByID(c.Context(), teamID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return apierr.NewAPIError(fiber.StatusNotFound, "team not found").Respond(c)
 			}
-			if t.OrgID == nil || *t.OrgID != req.OrgID {
-				return apierr.NewAPIError(fiber.StatusBadRequest, "team does not belong to the specified organization").Respond(c)
-			}
+			return apierr.ErrInternalError.Respond(c, err)
+		}
+		if t.OrgID == nil || *t.OrgID != req.OrgID {
+			return apierr.NewAPIError(fiber.StatusBadRequest, "team does not belong to the specified organization").Respond(c)
 		}
 	}
 

--- a/internal/handler/apikey_test.go
+++ b/internal/handler/apikey_test.go
@@ -60,6 +60,63 @@ func TestCreateAPIKey_MissingName(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestCreateAPIKey_RejectsTeamOutsideOrg(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
+
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	orgID := teams[0].OrgID
+	require.NotNil(t, orgID)
+
+	otherOrg, err := store.CreateOrganization(ctx, "Unrelated Org")
+	require.NoError(t, err)
+	otherTeam, err := store.CreateTeamWithOrg(ctx, "Unrelated Team", otherOrg.ID)
+	require.NoError(t, err)
+
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"bad-scope","org_id":%q,"team_ids":[%q],"operation":"read_render"}`, orgID.String(), otherTeam.ID.String()), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	assert.Equal(t, "team does not belong to the specified organization", body["error"])
+
+	keys, err := store.ListAPIKeysForOrg(ctx, *orgID)
+	require.NoError(t, err)
+	assert.Empty(t, keys)
+}
+
+func TestCreateAPIKey_RejectsUnknownTeam(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	ctx := context.Background()
+	session, err := store.GetSessionByToken(ctx, token)
+	require.NoError(t, err)
+
+	teams, err := store.GetUserTeams(ctx, session.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	orgID := teams[0].OrgID
+	require.NotNil(t, orgID)
+
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"missing-team","org_id":%q,"team_ids":[%q]}`, orgID.String(), "00000000-0000-0000-0000-000000000001"), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	assert.Equal(t, "team not found", body["error"])
+}
+
 func TestCreateAPIKey_RequiresAccessToken(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)


### PR DESCRIPTION
## Summary

This fixes API key creation so explicit `team_ids` are validated against the requested `org_id` before a key is created.

Previously, the validation loop only ran inside the empty `team_ids` branch, which meant non-empty team scopes were never checked. A request could create an API key for one organization while attaching a team from another organization.

## What changed

- Validate every supplied team ID during API key creation.
- Return `404` when a supplied team does not exist.
- Return `400` when a supplied team belongs to a different organization.
- Preserve the existing org-wide behavior for omitted or empty `team_ids`.
- Add regression coverage for cross-organization and missing-team cases.
- Update the API key OpenAPI metadata and regenerate the bundled spec.
- Add `CONTRIBUTING.md` with testing, OpenAPI, and `ape-commit` commit message guidance.

## Validation

- `make spec-bundle`
- `git diff --check`
- `go test -race -count=1 -p 1 ./...`
- `go test ./internal/handler -run 'TestCreateAPIKey_(RejectsTeamOutsideOrg|RejectsUnknownTeam|Success|GlobalScope)' -count=1 -v`

Note: the focused API key tests use the repo's integration-test helper, so they skip locally when Postgres is unavailable. I also ran `make check`; after installing `golangci-lint`, it stops on existing repository-wide lint findings outside this change, mostly unchecked close/write errors and a couple of pre-existing formatting/static-analysis issues.