### PR TITLE
Add team creator as admin member on team creation

### DIFF
--- a/internal/handler/team.go
+++ b/internal/handler/team.go
@@ -72,6 +72,11 @@ func CreateTeam(c *fiber.Ctx) error {
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
+
+	if err := store.AddTeamMember(c.Context(), team.ID, userID); err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"team": team})
 }
 


### PR DESCRIPTION
Fixes #4

## What

- Add `store.AddTeamMember` call in `CreateTeam` handler after team creation
- Assign creator the `admin` role automatically (first member of an empty team)

## Why

`store.CreateTeamWithOrg` only inserts into `teams`. No row was added to
`team_members` for the creator, so `GetUserTeams` excluded the new team and
all editor-gated operations returned `403`.

## How

- Call `store.AddTeamMember(ctx, team.ID, userID)` immediately after
  `store.CreateTeamWithOrg` in `internal/handler/team.go`
- `AddTeamMember` already handles the count-based role promotion (admin when empty)

## Testing

- Run `go test ./internal/handler/...` — passes
- Run `go test ./...` — passes

### Manual Verification
Ran the full repro from the issue against a local instance:

1. Logged in, created a team via POST /v1/orgs/{orgID}/teams
2. Created a prompt in the new team as the creator — POST /v1/teams/{teamID}/prompts
   → 201 Created (previously 403 before this fix)
3. Verified team membership — GET /v1/teams/{teamID}/members

Organization ID: a34b0263-4365-4cc3-844b-60091b847fe1
Created Team ID: 1278316b-c269-4421-b057-569e6ae46cb0

Created Prompt:
{
    "prompt": {
        "id": "f57e5552-4e49-4877-a882-3874048aa85e",
        "team_id": "1278316b-c269-4421-b057-569e6ae46cb0",
        "slug": "test_slug_1614842441",
        "name": "test-prompt-1779233094",
        "description": "",
        "status": "active",
        "created_at": "2026-07-06T23:23:16.914151Z",
        "updated_at": "2026-07-06T23:23:16.914151Z"
    }
}

Team Members:
{
    "limit": 10,
    "members": [
        {
            "user_id": "122b98a3-4177-4f27-84e7-f85e1544240e",
            "email": "<test-user-email>",
            "role": "admin",
            "created_at": "2026-07-06T23:23:16.856355Z"
        }
    ],
    "page": 1,
    "total": 1
}