### PR TITLE
Add model configuration to prompt versions

### DIFF
--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -2289,6 +2289,7 @@ paths:
         - 'TestRenderLive_NoLiveVersion: Verifies that requesting a render with only ''draft'' versions fails with 404 and ''no live version found for this prompt''.'
         - 'TestRenderLive_NoVariables: Verifies static templates render correctly when empty variables are supplied.'
         - 'TestRenderLive_MissingVariable: Verifies missing template variables fail with 422 instead of rendering placeholder text.'
+        - 'TestRenderLive_IncludesModel: Verifies render responses include the prompt version model.'
       requestBody:
         required: true
         content:
@@ -2366,8 +2367,11 @@ paths:
             format: uuid
       x-edge-cases:
         - Validates template string syntax using Go's text/template parser before creating the entry.
+        - If model is supplied, it must be a non-empty string after trimming whitespace.
       x-test-coverage:
         - 'TestCreateVersion_Success: Verifies version number is incremented to draft status 1.'
+        - 'TestCreateVersion_WithModel: Verifies prompt version model is persisted and returned.'
+        - 'TestCreateVersion_BlankModel: Verifies blank model values reject with 400.'
         - 'TestCreateVersion_InvalidTemplate: Verifies syntax check fails with 400 and ''invalid template''.'
         - 'TestCreateVersion_MissingTemplate: Verifies missing template rejects with 400 and ''template is required''.'
         - 'TestCreateVersion_PromptNotFound: Verifies 404 response on missing parent prompt UUID.'
@@ -2578,8 +2582,10 @@ paths:
             type: string
       x-edge-cases:
         - Fails with 422 Unprocessable Entity if the version status is not 'draft' (e.g. attempting to update a live/archived template).
+        - Allows updating model without changing the template while the version is still a draft.
       x-test-coverage:
         - 'TestUpdateVersion_Draft: Verifies modification updates template content and returns 200.'
+        - 'TestUpdateVersion_ModelOnly: Verifies model-only updates on draft versions.'
         - 'TestUpdateVersion_LiveVersionRejected: Verifies that updating a published live template version fails with 422 and ''only draft versions can be modified''.'
       requestBody:
         required: true
@@ -2919,7 +2925,7 @@ paths:
       summary: Duplicate Prompt Version
       description: |
         Copies the specified prompt version's template to create a new prompt version in draft state.
-        This operation does not copy any associated payloads, only the prompt template and other metadata.
+        This operation does not copy any associated payloads, only the prompt template and model.
       operationId: duplicateVersion
       tags:
         - Prompt Versions
@@ -3762,6 +3768,11 @@ components:
             - live
             - archived
           description: Active lifecycle status of this template version.
+        model:
+          type: string
+          nullable: true
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1
         created_at:
           type: string
           format: date-time
@@ -3781,6 +3792,7 @@ components:
         - version
         - template
         - status
+        - model
         - created_at
         - published_at
         - tags
@@ -3814,11 +3826,17 @@ components:
           items:
             type: string
           description: List of tag strings assigned to this version.
+        model:
+          type: string
+          nullable: true
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1
       required:
         - rendered
         - version
         - slug
         - tags
+        - model
     PromptPayload:
       type: object
       properties:
@@ -4062,6 +4080,10 @@ components:
         template:
           type: string
           example: Hello, {{.name}}!
+        model:
+          type: string
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1
       required:
         - template
     UpdateVersionRequest:
@@ -4070,5 +4092,7 @@ components:
         template:
           type: string
           example: Hello, {{.name}}! Count is {{.count}}.
-      required:
-        - template
+        model:
+          type: string
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1-mini

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -2289,7 +2289,7 @@ paths:
         - 'TestRenderLive_NoLiveVersion: Verifies that requesting a render with only ''draft'' versions fails with 404 and ''no live version found for this prompt''.'
         - 'TestRenderLive_NoVariables: Verifies static templates render correctly when empty variables are supplied.'
         - 'TestRenderLive_MissingVariable: Verifies missing template variables fail with 422 instead of rendering placeholder text.'
-        - 'TestRenderLive_IncludesModel: Verifies render responses include the prompt version model.'
+        - 'TestRenderLive_IncludesModelConfig: Verifies render responses include the prompt version model and parameters.'
       requestBody:
         required: true
         content:
@@ -2368,10 +2368,12 @@ paths:
       x-edge-cases:
         - Validates template string syntax using Go's text/template parser before creating the entry.
         - If model is supplied, it must be a non-empty string after trimming whitespace.
+        - If model_params is supplied, it must be a JSON object; nested provider-specific values are supported.
       x-test-coverage:
         - 'TestCreateVersion_Success: Verifies version number is incremented to draft status 1.'
-        - 'TestCreateVersion_WithModel: Verifies prompt version model is persisted and returned.'
+        - 'TestCreateVersion_WithModelConfig: Verifies model and nested model parameters are persisted and returned.'
         - 'TestCreateVersion_BlankModel: Verifies blank model values reject with 400.'
+        - 'TestCreateVersion_InvalidModelParams: Verifies non-object model parameters reject with 400.'
         - 'TestCreateVersion_InvalidTemplate: Verifies syntax check fails with 400 and ''invalid template''.'
         - 'TestCreateVersion_MissingTemplate: Verifies missing template rejects with 400 and ''template is required''.'
         - 'TestCreateVersion_PromptNotFound: Verifies 404 response on missing parent prompt UUID.'
@@ -2582,10 +2584,10 @@ paths:
             type: string
       x-edge-cases:
         - Fails with 422 Unprocessable Entity if the version status is not 'draft' (e.g. attempting to update a live/archived template).
-        - Allows updating model without changing the template while the version is still a draft.
+        - Allows updating model configuration without changing the template while the version is still a draft.
       x-test-coverage:
         - 'TestUpdateVersion_Draft: Verifies modification updates template content and returns 200.'
-        - 'TestUpdateVersion_ModelOnly: Verifies model-only updates on draft versions.'
+        - 'TestUpdateVersion_ModelConfigOnly: Verifies model configuration updates on draft versions without changing the template.'
         - 'TestUpdateVersion_LiveVersionRejected: Verifies that updating a published live template version fails with 422 and ''only draft versions can be modified''.'
       requestBody:
         required: true
@@ -2925,7 +2927,7 @@ paths:
       summary: Duplicate Prompt Version
       description: |
         Copies the specified prompt version's template to create a new prompt version in draft state.
-        This operation does not copy any associated payloads, only the prompt template and model.
+        This operation does not copy any associated payloads, only the prompt template and model configuration.
       operationId: duplicateVersion
       tags:
         - Prompt Versions
@@ -3771,11 +3773,19 @@ components:
         model:
           type: string
           nullable: true
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: anthropic/claude-opus-4-6
+        model_params:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.7
+            max_tokens: 1024
+            thinking:
+              type: enabled
+              budget_tokens: 512
         created_at:
           type: string
           format: date-time
@@ -3796,6 +3806,7 @@ components:
         - template
         - status
         - model
+        - model_params
         - created_at
         - published_at
         - tags
@@ -3832,17 +3843,23 @@ components:
         model:
           type: string
           nullable: true
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: anthropic/claude-opus-4-6
+        model_params:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.7
+            max_tokens: 1024
       required:
         - rendered
         - version
         - slug
         - tags
         - model
+        - model_params
     PromptPayload:
       type: object
       properties:
@@ -4088,11 +4105,15 @@ components:
           example: Hello, {{.name}}!
         model:
           type: string
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: anthropic/claude-opus-4-6
+        model_params:
+          type: object
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.7
+            max_tokens: 1024
       required:
         - template
     UpdateVersionRequest:
@@ -4103,8 +4124,11 @@ components:
           example: Hello, {{.name}}! Count is {{.count}}.
         model:
           type: string
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: openai/gpt-4.1-mini?temp=0.2
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: openai/gpt-4.1-mini
+        model_params:
+          type: object
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.2

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -3771,8 +3771,11 @@ components:
         model:
           type: string
           nullable: true
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
         created_at:
           type: string
           format: date-time
@@ -3829,8 +3832,11 @@ components:
         model:
           type: string
           nullable: true
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
       required:
         - rendered
         - version
@@ -4082,8 +4088,11 @@ components:
           example: Hello, {{.name}}!
         model:
           type: string
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
       required:
         - template
     UpdateVersionRequest:
@@ -4094,5 +4103,8 @@ components:
           example: Hello, {{.name}}! Count is {{.count}}.
         model:
           type: string
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1-mini
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: openai/gpt-4.1-mini?temp=0.2

--- a/docs/openapi/prompt-renders.yaml
+++ b/docs/openapi/prompt-renders.yaml
@@ -28,6 +28,7 @@ paths:
         - "TestRenderLive_NoLiveVersion: Verifies that requesting a render with only 'draft' versions fails with 404 and 'no live version found for this prompt'."
         - "TestRenderLive_NoVariables: Verifies static templates render correctly when empty variables are supplied."
         - "TestRenderLive_MissingVariable: Verifies missing template variables fail with 422 instead of rendering placeholder text."
+        - "TestRenderLive_IncludesModel: Verifies render responses include the prompt version model."
       requestBody:
         required: true
         content:
@@ -189,8 +190,14 @@ components:
           items:
             type: string
           description: List of tag strings assigned to this version.
+        model:
+          type: string
+          nullable: true
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1
       required:
         - rendered
         - version
         - slug
         - tags
+        - model

--- a/docs/openapi/prompt-renders.yaml
+++ b/docs/openapi/prompt-renders.yaml
@@ -193,8 +193,11 @@ components:
         model:
           type: string
           nullable: true
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
       required:
         - rendered
         - version

--- a/docs/openapi/prompt-renders.yaml
+++ b/docs/openapi/prompt-renders.yaml
@@ -28,7 +28,7 @@ paths:
         - "TestRenderLive_NoLiveVersion: Verifies that requesting a render with only 'draft' versions fails with 404 and 'no live version found for this prompt'."
         - "TestRenderLive_NoVariables: Verifies static templates render correctly when empty variables are supplied."
         - "TestRenderLive_MissingVariable: Verifies missing template variables fail with 422 instead of rendering placeholder text."
-        - "TestRenderLive_IncludesModel: Verifies render responses include the prompt version model."
+        - "TestRenderLive_IncludesModelConfig: Verifies render responses include the prompt version model and parameters."
       requestBody:
         required: true
         content:
@@ -193,14 +193,20 @@ components:
         model:
           type: string
           nullable: true
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: anthropic/claude-opus-4-6
+        model_params:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.7
+            max_tokens: 1024
       required:
         - rendered
         - version
         - slug
         - tags
         - model
+        - model_params

--- a/docs/openapi/prompt-versions.yaml
+++ b/docs/openapi/prompt-versions.yaml
@@ -22,8 +22,11 @@ paths:
             format: uuid
       x-edge-cases:
         - "Validates template string syntax using Go's text/template parser before creating the entry."
+        - "If model is supplied, it must be a non-empty string after trimming whitespace."
       x-test-coverage:
         - "TestCreateVersion_Success: Verifies version number is incremented to draft status 1."
+        - "TestCreateVersion_WithModel: Verifies prompt version model is persisted and returned."
+        - "TestCreateVersion_BlankModel: Verifies blank model values reject with 400."
         - "TestCreateVersion_InvalidTemplate: Verifies syntax check fails with 400 and 'invalid template'."
         - "TestCreateVersion_MissingTemplate: Verifies missing template rejects with 400 and 'template is required'."
         - "TestCreateVersion_PromptNotFound: Verifies 404 response on missing parent prompt UUID."
@@ -308,8 +311,10 @@ paths:
             type: string
       x-edge-cases:
         - "Fails with 422 Unprocessable Entity if the version status is not 'draft' (e.g. attempting to update a live/archived template)."
+        - "Allows updating model without changing the template while the version is still a draft."
       x-test-coverage:
         - "TestUpdateVersion_Draft: Verifies modification updates template content and returns 200."
+        - "TestUpdateVersion_ModelOnly: Verifies model-only updates on draft versions."
         - "TestUpdateVersion_LiveVersionRejected: Verifies that updating a published live template version fails with 422 and 'only draft versions can be modified'."
       requestBody:
         required: true
@@ -654,7 +659,7 @@ paths:
       summary: Duplicate Prompt Version
       description: |
         Copies the specified prompt version's template to create a new prompt version in draft state.
-        This operation does not copy any associated payloads, only the prompt template and other metadata.
+        This operation does not copy any associated payloads, only the prompt template and model.
       operationId: duplicateVersion
       tags:
         - Prompt Versions
@@ -906,6 +911,11 @@ components:
           type: string
           enum: [draft, stable, live, archived]
           description: Active lifecycle status of this template version.
+        model:
+          type: string
+          nullable: true
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1
         created_at:
           type: string
           format: date-time
@@ -925,6 +935,7 @@ components:
         - version
         - template
         - status
+        - model
         - created_at
         - published_at
         - tags
@@ -934,6 +945,10 @@ components:
         template:
           type: string
           example: "Hello, {{.name}}!"
+        model:
+          type: string
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1
       required:
         - template
     UpdateVersionRequest:
@@ -942,5 +957,7 @@ components:
         template:
           type: string
           example: "Hello, {{.name}}! Count is {{.count}}."
-      required:
-        - template
+        model:
+          type: string
+          description: Optional model name intended to execute this prompt version.
+          example: gpt-4.1-mini

--- a/docs/openapi/prompt-versions.yaml
+++ b/docs/openapi/prompt-versions.yaml
@@ -914,8 +914,11 @@ components:
         model:
           type: string
           nullable: true
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
         created_at:
           type: string
           format: date-time
@@ -947,8 +950,11 @@ components:
           example: "Hello, {{.name}}!"
         model:
           type: string
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
       required:
         - template
     UpdateVersionRequest:
@@ -959,5 +965,8 @@ components:
           example: "Hello, {{.name}}! Count is {{.count}}."
         model:
           type: string
-          description: Optional model name intended to execute this prompt version.
-          example: gpt-4.1-mini
+          description: |
+            Optional model spec intended to execute this prompt version.
+            Recommended format is `provider/model?key=value&key=value`, where query
+            parameters can carry provider-specific options such as temperature or token limits.
+          example: openai/gpt-4.1-mini?temp=0.2

--- a/docs/openapi/prompt-versions.yaml
+++ b/docs/openapi/prompt-versions.yaml
@@ -23,10 +23,12 @@ paths:
       x-edge-cases:
         - "Validates template string syntax using Go's text/template parser before creating the entry."
         - "If model is supplied, it must be a non-empty string after trimming whitespace."
+        - "If model_params is supplied, it must be a JSON object; nested provider-specific values are supported."
       x-test-coverage:
         - "TestCreateVersion_Success: Verifies version number is incremented to draft status 1."
-        - "TestCreateVersion_WithModel: Verifies prompt version model is persisted and returned."
+        - "TestCreateVersion_WithModelConfig: Verifies model and nested model parameters are persisted and returned."
         - "TestCreateVersion_BlankModel: Verifies blank model values reject with 400."
+        - "TestCreateVersion_InvalidModelParams: Verifies non-object model parameters reject with 400."
         - "TestCreateVersion_InvalidTemplate: Verifies syntax check fails with 400 and 'invalid template'."
         - "TestCreateVersion_MissingTemplate: Verifies missing template rejects with 400 and 'template is required'."
         - "TestCreateVersion_PromptNotFound: Verifies 404 response on missing parent prompt UUID."
@@ -311,10 +313,10 @@ paths:
             type: string
       x-edge-cases:
         - "Fails with 422 Unprocessable Entity if the version status is not 'draft' (e.g. attempting to update a live/archived template)."
-        - "Allows updating model without changing the template while the version is still a draft."
+        - "Allows updating model configuration without changing the template while the version is still a draft."
       x-test-coverage:
         - "TestUpdateVersion_Draft: Verifies modification updates template content and returns 200."
-        - "TestUpdateVersion_ModelOnly: Verifies model-only updates on draft versions."
+        - "TestUpdateVersion_ModelConfigOnly: Verifies model configuration updates on draft versions without changing the template."
         - "TestUpdateVersion_LiveVersionRejected: Verifies that updating a published live template version fails with 422 and 'only draft versions can be modified'."
       requestBody:
         required: true
@@ -659,7 +661,7 @@ paths:
       summary: Duplicate Prompt Version
       description: |
         Copies the specified prompt version's template to create a new prompt version in draft state.
-        This operation does not copy any associated payloads, only the prompt template and model.
+        This operation does not copy any associated payloads, only the prompt template and model configuration.
       operationId: duplicateVersion
       tags:
         - Prompt Versions
@@ -914,11 +916,19 @@ components:
         model:
           type: string
           nullable: true
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: anthropic/claude-opus-4-6
+        model_params:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.7
+            max_tokens: 1024
+            thinking:
+              type: enabled
+              budget_tokens: 512
         created_at:
           type: string
           format: date-time
@@ -939,6 +949,7 @@ components:
         - template
         - status
         - model
+        - model_params
         - created_at
         - published_at
         - tags
@@ -950,11 +961,15 @@ components:
           example: "Hello, {{.name}}!"
         model:
           type: string
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: anthropic/opus-4.6?temp=0.7&max_tokens=1024
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: anthropic/claude-opus-4-6
+        model_params:
+          type: object
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.7
+            max_tokens: 1024
       required:
         - template
     UpdateVersionRequest:
@@ -965,8 +980,11 @@ components:
           example: "Hello, {{.name}}! Count is {{.count}}."
         model:
           type: string
-          description: |
-            Optional model spec intended to execute this prompt version.
-            Recommended format is `provider/model?key=value&key=value`, where query
-            parameters can carry provider-specific options such as temperature or token limits.
-          example: openai/gpt-4.1-mini?temp=0.2
+          description: Optional `provider/model` identifier intended to execute this prompt version.
+          example: openai/gpt-4.1-mini
+        model_params:
+          type: object
+          additionalProperties: true
+          description: Optional provider-specific model parameters. Nested values are supported.
+          example:
+            temperature: 0.2

--- a/internal/db/migrations/020_prompt_version_model.sql
+++ b/internal/db/migrations/020_prompt_version_model.sql
@@ -1,0 +1,2 @@
+ALTER TABLE prompt_versions
+ADD COLUMN model TEXT;

--- a/internal/db/migrations/020_prompt_version_model.sql
+++ b/internal/db/migrations/020_prompt_version_model.sql
@@ -1,2 +1,3 @@
 ALTER TABLE prompt_versions
-ADD COLUMN model TEXT;
+ADD COLUMN model TEXT,
+ADD COLUMN model_params JSONB;

--- a/internal/handler/render.go
+++ b/internal/handler/render.go
@@ -100,5 +100,6 @@ func executeRender(c *fiber.Ctx, prompt *model.Prompt, version *model.PromptVers
 		"version":  version.Version,
 		"slug":     prompt.Slug,
 		"tags":     version.Tags,
+		"model":    version.Model,
 	})
 }

--- a/internal/handler/render.go
+++ b/internal/handler/render.go
@@ -96,10 +96,11 @@ func executeRender(c *fiber.Ctx, prompt *model.Prompt, version *model.PromptVers
 	}
 
 	return c.JSON(fiber.Map{
-		"rendered": buf.String(),
-		"version":  version.Version,
-		"slug":     prompt.Slug,
-		"tags":     version.Tags,
-		"model":    version.Model,
+		"rendered":     buf.String(),
+		"version":      version.Version,
+		"slug":         prompt.Slug,
+		"tags":         version.Tags,
+		"model":        version.Model,
+		"model_params": version.ModelParams,
 	})
 }

--- a/internal/handler/render_test.go
+++ b/internal/handler/render_test.go
@@ -125,6 +125,44 @@ func TestRenderLive_MissingVariable(t *testing.T) {
 	assert.Contains(t, errMsg, "template execution failed")
 }
 
+func TestRenderLive_IncludesModel(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	id := setupPrompt(t, a, token)
+	slug := getPromptSlug(t, a, id, token)
+
+	req := newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/versions", id),
+		`{"template":"Hi {{.user}}!","model":"gpt-4.1"}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	req = newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	req = newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	req = newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/render", slug),
+		`{"variables":{"user":"Alice"}}`, token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	assert.Equal(t, "Hi Alice!", body["rendered"])
+	assert.Equal(t, "gpt-4.1", body["model"])
+}
+
 func TestRenderVersion_Draft(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)

--- a/internal/handler/render_test.go
+++ b/internal/handler/render_test.go
@@ -125,7 +125,7 @@ func TestRenderLive_MissingVariable(t *testing.T) {
 	assert.Contains(t, errMsg, "template execution failed")
 }
 
-func TestRenderLive_IncludesModel(t *testing.T) {
+func TestRenderLive_IncludesModelConfig(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
 	id := setupPrompt(t, a, token)
@@ -133,7 +133,7 @@ func TestRenderLive_IncludesModel(t *testing.T) {
 
 	req := newReq(t, http.MethodPost,
 		fmt.Sprintf("/v1/prompts/%s/versions", id),
-		`{"template":"Hi {{.user}}!","model":"gpt-4.1"}`, token)
+		`{"template":"Hi {{.user}}!","model":"openai/gpt-4.1","model_params":{"temperature":0.2}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
@@ -160,7 +160,8 @@ func TestRenderLive_IncludesModel(t *testing.T) {
 
 	body := decodeBody(t, resp)
 	assert.Equal(t, "Hi Alice!", body["rendered"])
-	assert.Equal(t, "gpt-4.1", body["model"])
+	assert.Equal(t, "openai/gpt-4.1", body["model"])
+	assert.Equal(t, map[string]any{"temperature": 0.2}, body["model_params"])
 }
 
 func TestRenderVersion_Draft(t *testing.T) {

--- a/internal/handler/version.go
+++ b/internal/handler/version.go
@@ -17,10 +17,12 @@ import (
 
 type createVersionRequest struct {
 	Template string `json:"template"`
+	Model    string `json:"model"`
 }
 
 type updateVersionRequest struct {
-	Template string `json:"template"`
+	Template *string `json:"template"`
+	Model    *string `json:"model"`
 }
 
 func CreateVersion(c *fiber.Ctx) error {
@@ -63,8 +65,12 @@ func CreateVersion(c *fiber.Ctx) error {
 	if _, err := template.New("").Parse(req.Template); err != nil {
 		return apierr.ErrInvalidTemplate.WithDetails(err.Error()).Respond(c, err)
 	}
+	versionModel, err := normalizeVersionModel(req.Model)
+	if err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, err.Error()).Respond(c)
+	}
 
-	version, err := store.CreateVersion(c.Context(), promptID, req.Template)
+	version, err := store.CreateVersionWithModel(c.Context(), promptID, req.Template, versionModel)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -193,14 +199,23 @@ func UpdateVersion(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return apierr.ErrInvalidRequestBody.Respond(c)
 	}
-	if req.Template == "" {
-		return apierr.ErrTemplateRequired.Respond(c)
+	if req.Template == nil && req.Model == nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "template or model is required").Respond(c)
 	}
-	if _, err := template.New("").Parse(req.Template); err != nil {
-		return apierr.ErrInvalidTemplate.WithDetails(err.Error()).Respond(c, err)
+	if req.Template != nil {
+		if *req.Template == "" {
+			return apierr.ErrTemplateRequired.Respond(c)
+		}
+		if _, err := template.New("").Parse(*req.Template); err != nil {
+			return apierr.ErrInvalidTemplate.WithDetails(err.Error()).Respond(c, err)
+		}
+	}
+	versionModel, err := normalizeVersionModelPtr(req.Model)
+	if err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, err.Error()).Respond(c)
 	}
 
-	updated, err := store.UpdateVersionTemplate(c.Context(), existing.ID, req.Template)
+	updated, err := store.UpdateVersionDraft(c.Context(), existing.ID, req.Template, versionModel)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -465,4 +480,22 @@ func resolveVersion(ctx context.Context, promptID uuid.UUID, versionParam string
 		return store.GetVersion(ctx, promptID, versionNum)
 	}
 	return store.GetVersionByTag(ctx, promptID, versionParam)
+}
+
+func normalizeVersionModel(modelName string) (*string, error) {
+	if modelName == "" {
+		return nil, nil
+	}
+	return normalizeVersionModelPtr(&modelName)
+}
+
+func normalizeVersionModelPtr(modelName *string) (*string, error) {
+	if modelName == nil {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(*modelName)
+	if trimmed == "" {
+		return nil, errors.New("model must not be empty")
+	}
+	return &trimmed, nil
 }

--- a/internal/handler/version.go
+++ b/internal/handler/version.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -16,13 +17,15 @@ import (
 )
 
 type createVersionRequest struct {
-	Template string `json:"template"`
-	Model    string `json:"model"`
+	Template    string          `json:"template"`
+	Model       string          `json:"model"`
+	ModelParams json.RawMessage `json:"model_params"`
 }
 
 type updateVersionRequest struct {
-	Template *string `json:"template"`
-	Model    *string `json:"model"`
+	Template    *string         `json:"template"`
+	Model       *string         `json:"model"`
+	ModelParams json.RawMessage `json:"model_params"`
 }
 
 func CreateVersion(c *fiber.Ctx) error {
@@ -70,7 +73,15 @@ func CreateVersion(c *fiber.Ctx) error {
 		return apierr.NewAPIError(fiber.StatusBadRequest, err.Error()).Respond(c)
 	}
 
-	version, err := store.CreateVersionWithModel(c.Context(), promptID, req.Template, versionModel)
+	if err := validateModelParams(req.ModelParams); err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, err.Error()).Respond(c)
+	}
+
+	version, err := store.CreateVersion(c.Context(), promptID, store.CreateVersionParams{
+		Template:    req.Template,
+		Model:       versionModel,
+		ModelParams: req.ModelParams,
+	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -199,8 +210,8 @@ func UpdateVersion(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return apierr.ErrInvalidRequestBody.Respond(c)
 	}
-	if req.Template == nil && req.Model == nil {
-		return apierr.NewAPIError(fiber.StatusBadRequest, "template or model is required").Respond(c)
+	if req.Template == nil && req.Model == nil && len(req.ModelParams) == 0 {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "template, model, or model_params is required").Respond(c)
 	}
 	if req.Template != nil {
 		if *req.Template == "" {
@@ -215,7 +226,15 @@ func UpdateVersion(c *fiber.Ctx) error {
 		return apierr.NewAPIError(fiber.StatusBadRequest, err.Error()).Respond(c)
 	}
 
-	updated, err := store.UpdateVersionDraft(c.Context(), existing.ID, req.Template, versionModel)
+	if err := validateModelParams(req.ModelParams); err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, err.Error()).Respond(c)
+	}
+
+	updated, err := store.UpdateVersion(c.Context(), existing.ID, store.UpdateVersionParams{
+		Template:    req.Template,
+		Model:       versionModel,
+		ModelParams: req.ModelParams,
+	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -498,4 +517,15 @@ func normalizeVersionModelPtr(modelName *string) (*string, error) {
 		return nil, errors.New("model must not be empty")
 	}
 	return &trimmed, nil
+}
+
+func validateModelParams(params json.RawMessage) error {
+	if len(params) == 0 {
+		return nil
+	}
+	var object map[string]any
+	if err := json.Unmarshal(params, &object); err != nil || object == nil {
+		return errors.New("model_params must be a JSON object")
+	}
+	return nil
 }

--- a/internal/handler/version_test.go
+++ b/internal/handler/version_test.go
@@ -27,6 +27,36 @@ func TestCreateVersion_Success(t *testing.T) {
 	assert.Equal(t, "Hello, {{.name}}!", v["template"])
 }
 
+func TestCreateVersion_WithModel(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	id := setupPrompt(t, a, token)
+
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions", id),
+		`{"template":"Hello, {{.name}}!","model":"gpt-4.1"}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	v := body["version"].(map[string]any)
+	assert.Equal(t, "Hello, {{.name}}!", v["template"])
+	assert.Equal(t, "gpt-4.1", v["model"])
+}
+
+func TestCreateVersion_BlankModel(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	id := setupPrompt(t, a, token)
+
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions", id),
+		`{"template":"Hello","model":"  "}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
 func TestCreateVersion_InvalidTemplate(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
@@ -163,6 +193,24 @@ func TestUpdateVersion_Success(t *testing.T) {
 	body := decodeBody(t, resp)
 	v := body["version"].(map[string]any)
 	assert.Equal(t, "updated template", v["template"])
+}
+
+func TestUpdateVersion_ModelOnly(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	id := setupPrompt(t, a, token)
+	setupVersion(t, a, token, id, "original template")
+
+	req := newReq(t, http.MethodPut, fmt.Sprintf("/v1/prompts/%s/versions/1", id),
+		`{"model":"gpt-4.1-mini"}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	v := body["version"].(map[string]any)
+	assert.Equal(t, "original template", v["template"])
+	assert.Equal(t, "gpt-4.1-mini", v["model"])
 }
 
 func TestUpdateVersion_NonDraftRejected(t *testing.T) {

--- a/internal/handler/version_test.go
+++ b/internal/handler/version_test.go
@@ -27,13 +27,13 @@ func TestCreateVersion_Success(t *testing.T) {
 	assert.Equal(t, "Hello, {{.name}}!", v["template"])
 }
 
-func TestCreateVersion_WithModel(t *testing.T) {
+func TestCreateVersion_WithModelConfig(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
 	id := setupPrompt(t, a, token)
 
 	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions", id),
-		`{"template":"Hello, {{.name}}!","model":"gpt-4.1"}`, token)
+		`{"template":"Hello, {{.name}}!","model":"openai/gpt-4.1","model_params":{"temperature":0.2,"response_format":{"type":"json_object"}}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
@@ -41,7 +41,11 @@ func TestCreateVersion_WithModel(t *testing.T) {
 	body := decodeBody(t, resp)
 	v := body["version"].(map[string]any)
 	assert.Equal(t, "Hello, {{.name}}!", v["template"])
-	assert.Equal(t, "gpt-4.1", v["model"])
+	assert.Equal(t, "openai/gpt-4.1", v["model"])
+	assert.Equal(t, map[string]any{
+		"temperature":     0.2,
+		"response_format": map[string]any{"type": "json_object"},
+	}, v["model_params"])
 }
 
 func TestCreateVersion_BlankModel(t *testing.T) {
@@ -51,6 +55,19 @@ func TestCreateVersion_BlankModel(t *testing.T) {
 
 	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions", id),
 		`{"template":"Hello","model":"  "}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestCreateVersion_InvalidModelParams(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	id := setupPrompt(t, a, token)
+
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions", id),
+		`{"template":"Hello","model_params":["invalid"]}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
@@ -195,14 +212,14 @@ func TestUpdateVersion_Success(t *testing.T) {
 	assert.Equal(t, "updated template", v["template"])
 }
 
-func TestUpdateVersion_ModelOnly(t *testing.T) {
+func TestUpdateVersion_ModelConfigOnly(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
 	id := setupPrompt(t, a, token)
 	setupVersion(t, a, token, id, "original template")
 
 	req := newReq(t, http.MethodPut, fmt.Sprintf("/v1/prompts/%s/versions/1", id),
-		`{"model":"gpt-4.1-mini"}`, token)
+		`{"model":"openai/gpt-4.1-mini","model_params":{"temperature":0.5}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -210,7 +227,8 @@ func TestUpdateVersion_ModelOnly(t *testing.T) {
 	body := decodeBody(t, resp)
 	v := body["version"].(map[string]any)
 	assert.Equal(t, "original template", v["template"])
-	assert.Equal(t, "gpt-4.1-mini", v["model"])
+	assert.Equal(t, "openai/gpt-4.1-mini", v["model"])
+	assert.Equal(t, map[string]any{"temperature": 0.5}, v["model_params"])
 }
 
 func TestUpdateVersion_NonDraftRejected(t *testing.T) {

--- a/internal/model/prompt.go
+++ b/internal/model/prompt.go
@@ -35,6 +35,7 @@ type PromptVersion struct {
 	Version     int        `json:"version"`
 	Template    string     `json:"template"`
 	Status      string     `json:"status"`
+	Model       *string    `json:"model"`
 	CreatedAt   time.Time  `json:"created_at"`
 	PublishedAt *time.Time `json:"published_at"`
 	Tags        []string   `json:"tags"`

--- a/internal/model/prompt.go
+++ b/internal/model/prompt.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,13 +31,14 @@ const (
 )
 
 type PromptVersion struct {
-	ID          uuid.UUID  `json:"id"`
-	PromptID    uuid.UUID  `json:"prompt_id"`
-	Version     int        `json:"version"`
-	Template    string     `json:"template"`
-	Status      string     `json:"status"`
-	Model       *string    `json:"model"`
-	CreatedAt   time.Time  `json:"created_at"`
-	PublishedAt *time.Time `json:"published_at"`
-	Tags        []string   `json:"tags"`
+	ID          uuid.UUID       `json:"id"`
+	PromptID    uuid.UUID       `json:"prompt_id"`
+	Version     int             `json:"version"`
+	Template    string          `json:"template"`
+	Status      string          `json:"status"`
+	Model       *string         `json:"model"`
+	ModelParams json.RawMessage `json:"model_params"`
+	CreatedAt   time.Time       `json:"created_at"`
+	PublishedAt *time.Time      `json:"published_at"`
+	Tags        []string        `json:"tags"`
 }

--- a/internal/store/prompt_test.go
+++ b/internal/store/prompt_test.go
@@ -191,7 +191,7 @@ func TestListPrompts_Filters(t *testing.T) {
 	assert.Equal(t, pB.ID, prompts[0].ID)
 
 	// 2. Create version and tag for pA
-	v, err := store.CreateVersion(ctx, pA.ID, "template")
+	v, err := store.CreateVersion(ctx, pA.ID, store.CreateVersionParams{Template: "template"})
 	require.NoError(t, err)
 	err = store.SetTag(ctx, pA.ID, v.Version, "prod")
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestUpdatePrompt(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, p.ID, updated.ID)
 	assert.Equal(t, "my_prompt", updated.Slug) // slug remains unchanged
-	assert.Equal(t, "My Prompt", updated.Name)  // name remains unchanged
+	assert.Equal(t, "My Prompt", updated.Name) // name remains unchanged
 	assert.Equal(t, "Updated description", updated.Description)
 
 	// 2. Not found / Unauthorized team update

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -94,12 +94,12 @@ func GetTagsForPrompt(ctx context.Context, promptID uuid.UUID) (map[int][]string
 func GetVersionByTag(ctx context.Context, promptID uuid.UUID, tag string) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx, `
-		SELECT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.created_at, pv.published_at
+		SELECT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.model, pv.created_at, pv.published_at
 		FROM prompt_versions pv
 		JOIN prompt_tags pt ON pv.prompt_id = pt.prompt_id AND pv.version = pt.version
 		WHERE pt.prompt_id = $1 AND pt.tag = $2
 	`, promptID, tag).Scan(
-		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt,
+		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -94,12 +94,12 @@ func GetTagsForPrompt(ctx context.Context, promptID uuid.UUID) (map[int][]string
 func GetVersionByTag(ctx context.Context, promptID uuid.UUID, tag string) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx, `
-		SELECT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.model, pv.created_at, pv.published_at
+		SELECT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.model, pv.model_params, pv.created_at, pv.published_at
 		FROM prompt_versions pv
 		JOIN prompt_tags pt ON pv.prompt_id = pt.prompt_id AND pv.version = pt.version
 		WHERE pt.prompt_id = $1 AND pt.tag = $2
 	`, promptID, tag).Scan(
-		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt,
+		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/store/tag_test.go
+++ b/internal/store/tag_test.go
@@ -16,10 +16,10 @@ func TestTags_StoreLifecycle(t *testing.T) {
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
-	v1, err := store.CreateVersion(ctx, p.ID, "v1 template")
+	v1, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v1 template"})
 	require.NoError(t, err)
 
-	v2, err := store.CreateVersion(ctx, p.ID, "v2 template")
+	v2, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v2 template"})
 	require.NoError(t, err)
 
 	// 1. SetTag

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -15,6 +15,10 @@ import (
 )
 
 func CreateVersion(ctx context.Context, promptID uuid.UUID, template string) (*model.PromptVersion, error) {
+	return CreateVersionWithModel(ctx, promptID, template, nil)
+}
+
+func CreateVersionWithModel(ctx context.Context, promptID uuid.UUID, template string, versionModel *string) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx, `
 		WITH next_version AS (
@@ -22,12 +26,12 @@ func CreateVersion(ctx context.Context, promptID uuid.UUID, template string) (*m
 			FROM prompt_versions
 			WHERE prompt_id = $1
 		)
-		INSERT INTO prompt_versions (prompt_id, version, template, status)
-		SELECT $1, v, $2, 'draft'
+		INSERT INTO prompt_versions (prompt_id, version, template, status, model)
+		SELECT $1, v, $2, 'draft', $3
 		FROM next_version
-		RETURNING id, prompt_id, version, template, status, created_at, published_at
-	`, promptID, template).Scan(
-		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt,
+		RETURNING id, prompt_id, version, template, status, model, created_at, published_at
+	`, promptID, template, versionModel).Scan(
+		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create version: %w", err)
@@ -40,7 +44,7 @@ func DuplicateVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx, `
 		WITH source_version AS (
-			SELECT template
+			SELECT template, model
 			FROM prompt_versions
 			WHERE prompt_id = $1 AND version = $2
 		),
@@ -49,12 +53,12 @@ func DuplicateVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (
 			FROM prompt_versions
 			WHERE prompt_id = $1
 		)
-		INSERT INTO prompt_versions (prompt_id, version, template, status)
-		SELECT $1, nv.v, sv.template, 'draft'
+		INSERT INTO prompt_versions (prompt_id, version, template, status, model)
+		SELECT $1, nv.v, sv.template, 'draft', sv.model
 		FROM source_version sv, next_version nv
-		RETURNING id, prompt_id, version, template, status, created_at, published_at
+		RETURNING id, prompt_id, version, template, status, model, created_at, published_at
 	`, promptID, versionNum).Scan(
-		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt,
+		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -72,7 +76,7 @@ type VersionFilter struct {
 }
 
 func ListVersions(ctx context.Context, promptID uuid.UUID, filter VersionFilter) ([]*model.PromptVersion, error) {
-	query := `SELECT DISTINCT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.created_at, pv.published_at
+	query := `SELECT DISTINCT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.model, pv.created_at, pv.published_at
 		 FROM prompt_versions pv`
 	args := []any{promptID}
 	joins := ""
@@ -104,7 +108,7 @@ func ListVersions(ctx context.Context, promptID uuid.UUID, filter VersionFilter)
 	var versions []*model.PromptVersion
 	for rows.Next() {
 		v := &model.PromptVersion{}
-		if err := rows.Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt); err != nil {
+		if err := rows.Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt); err != nil {
 			return nil, err
 		}
 		versions = append(versions, v)
@@ -123,11 +127,11 @@ func ListVersions(ctx context.Context, promptID uuid.UUID, filter VersionFilter)
 func GetVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx,
-		`SELECT id, prompt_id, version, template, status, created_at, published_at
+		`SELECT id, prompt_id, version, template, status, model, created_at, published_at
 		 FROM prompt_versions
 		 WHERE prompt_id = $1 AND version = $2`,
 		promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -143,11 +147,11 @@ func GetVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*model
 func GetLiveVersion(ctx context.Context, promptID uuid.UUID) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx,
-		`SELECT id, prompt_id, version, template, status, created_at, published_at
+		`SELECT id, prompt_id, version, template, status, model, created_at, published_at
 		 FROM prompt_versions
 		 WHERE prompt_id = $1 AND status = 'live'`,
 		promptID,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -161,14 +165,34 @@ func GetLiveVersion(ctx context.Context, promptID uuid.UUID) (*model.PromptVersi
 }
 
 func UpdateVersionTemplate(ctx context.Context, id uuid.UUID, template string) (*model.PromptVersion, error) {
+	return UpdateVersionDraft(ctx, id, &template, nil)
+}
+
+func UpdateVersionDraft(ctx context.Context, id uuid.UUID, template *string, versionModel *string) (*model.PromptVersion, error) {
+	setClauses := []string{}
+	args := []any{}
+	if template != nil {
+		args = append(args, *template)
+		setClauses = append(setClauses, fmt.Sprintf("template = $%d", len(args)))
+	}
+	if versionModel != nil {
+		args = append(args, *versionModel)
+		setClauses = append(setClauses, fmt.Sprintf("model = $%d", len(args)))
+	}
+	if len(setClauses) == 0 {
+		return nil, ErrConflict
+	}
+	args = append(args, id)
+
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx,
-		`UPDATE prompt_versions
-		 SET template = $1
-		 WHERE id = $2 AND status = 'draft'
-		 RETURNING id, prompt_id, version, template, status, created_at, published_at`,
-		template, id,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt)
+		fmt.Sprintf(`UPDATE prompt_versions
+		 SET %s
+		 WHERE id = $%d AND status = 'draft'
+		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
+			strings.Join(setClauses, ", "), len(args)),
+		args...,
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -229,9 +253,9 @@ func PromoteVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*m
 		`UPDATE prompt_versions
 		 SET status = $1, published_at = $2
 		 WHERE prompt_id = $3 AND version = $4
-		 RETURNING id, prompt_id, version, template, status, created_at, published_at`,
+		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
 		nextStatus, now, promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		return nil, fmt.Errorf("promote version: %w", err)
 	}
@@ -275,9 +299,9 @@ func DemoteVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*mo
 		`UPDATE prompt_versions
 		 SET status = 'stable'
 		 WHERE prompt_id = $1 AND version = $2
-		 RETURNING id, prompt_id, version, template, status, created_at, published_at`,
+		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
 		promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		return nil, fmt.Errorf("demote version: %w", err)
 	}
@@ -321,9 +345,9 @@ func ArchiveVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*m
 		`UPDATE prompt_versions
 		 SET status = 'archived'
 		 WHERE prompt_id = $1 AND version = $2
-		 RETURNING id, prompt_id, version, template, status, created_at, published_at`,
+		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
 		promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		return nil, fmt.Errorf("archive version: %w", err)
 	}

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,11 +15,19 @@ import (
 	"github.com/px0-ai/px0/internal/model"
 )
 
-func CreateVersion(ctx context.Context, promptID uuid.UUID, template string) (*model.PromptVersion, error) {
-	return CreateVersionWithModel(ctx, promptID, template, nil)
+type CreateVersionParams struct {
+	Template    string
+	Model       *string
+	ModelParams json.RawMessage
 }
 
-func CreateVersionWithModel(ctx context.Context, promptID uuid.UUID, template string, versionModel *string) (*model.PromptVersion, error) {
+type UpdateVersionParams struct {
+	Template    *string
+	Model       *string
+	ModelParams json.RawMessage
+}
+
+func CreateVersion(ctx context.Context, promptID uuid.UUID, params CreateVersionParams) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx, `
 		WITH next_version AS (
@@ -26,12 +35,12 @@ func CreateVersionWithModel(ctx context.Context, promptID uuid.UUID, template st
 			FROM prompt_versions
 			WHERE prompt_id = $1
 		)
-		INSERT INTO prompt_versions (prompt_id, version, template, status, model)
-		SELECT $1, v, $2, 'draft', $3
+		INSERT INTO prompt_versions (prompt_id, version, template, status, model, model_params)
+		SELECT $1, v, $2, 'draft', $3, $4
 		FROM next_version
-		RETURNING id, prompt_id, version, template, status, model, created_at, published_at
-	`, promptID, template, versionModel).Scan(
-		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt,
+		RETURNING id, prompt_id, version, template, status, model, model_params, created_at, published_at
+	`, promptID, params.Template, params.Model, params.ModelParams).Scan(
+		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create version: %w", err)
@@ -44,7 +53,7 @@ func DuplicateVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx, `
 		WITH source_version AS (
-			SELECT template, model
+			SELECT template, model, model_params
 			FROM prompt_versions
 			WHERE prompt_id = $1 AND version = $2
 		),
@@ -53,12 +62,12 @@ func DuplicateVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (
 			FROM prompt_versions
 			WHERE prompt_id = $1
 		)
-		INSERT INTO prompt_versions (prompt_id, version, template, status, model)
-		SELECT $1, nv.v, sv.template, 'draft', sv.model
+		INSERT INTO prompt_versions (prompt_id, version, template, status, model, model_params)
+		SELECT $1, nv.v, sv.template, 'draft', sv.model, sv.model_params
 		FROM source_version sv, next_version nv
-		RETURNING id, prompt_id, version, template, status, model, created_at, published_at
+		RETURNING id, prompt_id, version, template, status, model, model_params, created_at, published_at
 	`, promptID, versionNum).Scan(
-		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt,
+		&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -76,7 +85,7 @@ type VersionFilter struct {
 }
 
 func ListVersions(ctx context.Context, promptID uuid.UUID, filter VersionFilter) ([]*model.PromptVersion, error) {
-	query := `SELECT DISTINCT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.model, pv.created_at, pv.published_at
+	query := `SELECT DISTINCT pv.id, pv.prompt_id, pv.version, pv.template, pv.status, pv.model, pv.model_params, pv.created_at, pv.published_at
 		 FROM prompt_versions pv`
 	args := []any{promptID}
 	joins := ""
@@ -108,7 +117,7 @@ func ListVersions(ctx context.Context, promptID uuid.UUID, filter VersionFilter)
 	var versions []*model.PromptVersion
 	for rows.Next() {
 		v := &model.PromptVersion{}
-		if err := rows.Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt); err != nil {
+		if err := rows.Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt); err != nil {
 			return nil, err
 		}
 		versions = append(versions, v)
@@ -127,11 +136,11 @@ func ListVersions(ctx context.Context, promptID uuid.UUID, filter VersionFilter)
 func GetVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx,
-		`SELECT id, prompt_id, version, template, status, model, created_at, published_at
+		`SELECT id, prompt_id, version, template, status, model, model_params, created_at, published_at
 		 FROM prompt_versions
 		 WHERE prompt_id = $1 AND version = $2`,
 		promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -147,11 +156,11 @@ func GetVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*model
 func GetLiveVersion(ctx context.Context, promptID uuid.UUID) (*model.PromptVersion, error) {
 	v := &model.PromptVersion{}
 	err := db.Pool.QueryRow(ctx,
-		`SELECT id, prompt_id, version, template, status, model, created_at, published_at
+		`SELECT id, prompt_id, version, template, status, model, model_params, created_at, published_at
 		 FROM prompt_versions
 		 WHERE prompt_id = $1 AND status = 'live'`,
 		promptID,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -164,20 +173,20 @@ func GetLiveVersion(ctx context.Context, promptID uuid.UUID) (*model.PromptVersi
 	return v, nil
 }
 
-func UpdateVersionTemplate(ctx context.Context, id uuid.UUID, template string) (*model.PromptVersion, error) {
-	return UpdateVersionDraft(ctx, id, &template, nil)
-}
-
-func UpdateVersionDraft(ctx context.Context, id uuid.UUID, template *string, versionModel *string) (*model.PromptVersion, error) {
+func UpdateVersion(ctx context.Context, id uuid.UUID, params UpdateVersionParams) (*model.PromptVersion, error) {
 	setClauses := []string{}
 	args := []any{}
-	if template != nil {
-		args = append(args, *template)
+	if params.Template != nil {
+		args = append(args, *params.Template)
 		setClauses = append(setClauses, fmt.Sprintf("template = $%d", len(args)))
 	}
-	if versionModel != nil {
-		args = append(args, *versionModel)
+	if params.Model != nil {
+		args = append(args, *params.Model)
 		setClauses = append(setClauses, fmt.Sprintf("model = $%d", len(args)))
+	}
+	if len(params.ModelParams) > 0 {
+		args = append(args, params.ModelParams)
+		setClauses = append(setClauses, fmt.Sprintf("model_params = $%d", len(args)))
 	}
 	if len(setClauses) == 0 {
 		return nil, ErrConflict
@@ -189,10 +198,10 @@ func UpdateVersionDraft(ctx context.Context, id uuid.UUID, template *string, ver
 		fmt.Sprintf(`UPDATE prompt_versions
 		 SET %s
 		 WHERE id = $%d AND status = 'draft'
-		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
+		 RETURNING id, prompt_id, version, template, status, model, model_params, created_at, published_at`,
 			strings.Join(setClauses, ", "), len(args)),
 		args...,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -253,9 +262,9 @@ func PromoteVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*m
 		`UPDATE prompt_versions
 		 SET status = $1, published_at = $2
 		 WHERE prompt_id = $3 AND version = $4
-		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
+		 RETURNING id, prompt_id, version, template, status, model, model_params, created_at, published_at`,
 		nextStatus, now, promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		return nil, fmt.Errorf("promote version: %w", err)
 	}
@@ -299,9 +308,9 @@ func DemoteVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*mo
 		`UPDATE prompt_versions
 		 SET status = 'stable'
 		 WHERE prompt_id = $1 AND version = $2
-		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
+		 RETURNING id, prompt_id, version, template, status, model, model_params, created_at, published_at`,
 		promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		return nil, fmt.Errorf("demote version: %w", err)
 	}
@@ -345,9 +354,9 @@ func ArchiveVersion(ctx context.Context, promptID uuid.UUID, versionNum int) (*m
 		`UPDATE prompt_versions
 		 SET status = 'archived'
 		 WHERE prompt_id = $1 AND version = $2
-		 RETURNING id, prompt_id, version, template, status, model, created_at, published_at`,
+		 RETURNING id, prompt_id, version, template, status, model, model_params, created_at, published_at`,
 		promptID, versionNum,
-	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.CreatedAt, &v.PublishedAt)
+	).Scan(&v.ID, &v.PromptID, &v.Version, &v.Template, &v.Status, &v.Model, &v.ModelParams, &v.CreatedAt, &v.PublishedAt)
 	if err != nil {
 		return nil, fmt.Errorf("archive version: %w", err)
 	}

--- a/internal/store/version_test.go
+++ b/internal/store/version_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ func TestCreateVersion(t *testing.T) {
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
-	v, err := store.CreateVersion(ctx, p.ID, "template content")
+	v, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "template content"})
 	require.NoError(t, err)
 	assert.Equal(t, p.ID, v.PromptID)
 	assert.Equal(t, 1, v.Version)
@@ -34,26 +35,33 @@ func TestCreateVersion(t *testing.T) {
 	assert.NotNil(t, v.CreatedAt)
 	assert.Nil(t, v.PublishedAt)
 
-	v2, err := store.CreateVersion(ctx, p.ID, "v2 template")
+	v2, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v2 template"})
 	require.NoError(t, err)
 	assert.Equal(t, 2, v2.Version)
 }
 
-func TestCreateVersionWithModel(t *testing.T) {
+func TestCreateVersionWithModelConfig(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
 	versionModel := "gpt-4.1"
-	v, err := store.CreateVersionWithModel(ctx, p.ID, "template content", &versionModel)
+	modelParams := json.RawMessage(`{"temperature":0.2,"response_format":{"type":"json_object"}}`)
+	v, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{
+		Template:    "template content",
+		Model:       &versionModel,
+		ModelParams: modelParams,
+	})
 	require.NoError(t, err)
 	require.NotNil(t, v.Model)
 	assert.Equal(t, versionModel, *v.Model)
+	assert.JSONEq(t, string(modelParams), string(v.ModelParams))
 
 	got, err := store.GetVersion(ctx, p.ID, v.Version)
 	require.NoError(t, err)
 	require.NotNil(t, got.Model)
 	assert.Equal(t, versionModel, *got.Model)
+	assert.JSONEq(t, string(modelParams), string(got.ModelParams))
 }
 
 func TestListVersions(t *testing.T) {
@@ -61,9 +69,9 @@ func TestListVersions(t *testing.T) {
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
-	v1, err := store.CreateVersion(ctx, p.ID, "v1")
+	v1, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v1"})
 	require.NoError(t, err)
-	v2, err := store.CreateVersion(ctx, p.ID, "v2")
+	v2, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v2"})
 	require.NoError(t, err)
 
 	_, err = store.PromoteVersion(ctx, p.ID, v1.Version) // draft -> stable
@@ -119,7 +127,7 @@ func TestGetVersion(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	store.CreateVersion(ctx, p.ID, "my template") //nolint:errcheck
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "my template"}) //nolint:errcheck
 
 	v, err := store.GetVersion(ctx, p.ID, 1)
 	require.NoError(t, err)
@@ -140,9 +148,9 @@ func TestGetLiveVersion(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	store.CreateVersion(ctx, p.ID, "live template") //nolint:errcheck
-	store.PromoteVersion(ctx, p.ID, 1)              // draft -> stable
-	store.PromoteVersion(ctx, p.ID, 1)              // stable -> live
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "live template"}) //nolint:errcheck
+	store.PromoteVersion(ctx, p.ID, 1)                                                   // draft -> stable
+	store.PromoteVersion(ctx, p.ID, 1)                                                   // stable -> live
 
 	v, err := store.GetLiveVersion(ctx, p.ID)
 	require.NoError(t, err)
@@ -154,19 +162,20 @@ func TestGetLiveVersion_NonePublished(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	store.CreateVersion(ctx, p.ID, "draft template") //nolint:errcheck
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "draft template"}) //nolint:errcheck
 
 	_, err := store.GetLiveVersion(ctx, p.ID)
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
 
-func TestUpdateVersionTemplate(t *testing.T) {
+func TestUpdateVersion(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	v, _ := store.CreateVersion(ctx, p.ID, "original")
+	v, _ := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "original"})
 
-	updated, err := store.UpdateVersionTemplate(ctx, v.ID, "updated")
+	template := "updated"
+	updated, err := store.UpdateVersion(ctx, v.ID, store.UpdateVersionParams{Template: &template})
 	require.NoError(t, err)
 	assert.Equal(t, "updated", updated.Template)
 	assert.Equal(t, model.VersionStatusDraft, updated.Status)
@@ -176,23 +185,33 @@ func TestUpdateVersionModel(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	v, err := store.CreateVersion(ctx, p.ID, "original")
+	v, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "original"})
 	require.NoError(t, err)
 
 	versionModel := "gpt-4.1-mini"
-	updated, err := store.UpdateVersionDraft(ctx, v.ID, nil, &versionModel)
+	modelParams := json.RawMessage(`{"temperature":0.5}`)
+	updated, err := store.UpdateVersion(ctx, v.ID, store.UpdateVersionParams{
+		Model:       &versionModel,
+		ModelParams: modelParams,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, "original", updated.Template)
 	require.NotNil(t, updated.Model)
 	assert.Equal(t, versionModel, *updated.Model)
+	assert.JSONEq(t, string(modelParams), string(updated.ModelParams))
 }
 
-func TestDuplicateVersionCopiesModel(t *testing.T) {
+func TestDuplicateVersionCopiesModelConfig(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 	versionModel := "gpt-4.1"
-	_, err := store.CreateVersionWithModel(ctx, p.ID, "original", &versionModel)
+	modelParams := json.RawMessage(`{"temperature":0.2}`)
+	_, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{
+		Template:    "original",
+		Model:       &versionModel,
+		ModelParams: modelParams,
+	})
 	require.NoError(t, err)
 
 	duplicated, err := store.DuplicateVersion(ctx, p.ID, 1)
@@ -200,17 +219,19 @@ func TestDuplicateVersionCopiesModel(t *testing.T) {
 	assert.Equal(t, "original", duplicated.Template)
 	require.NotNil(t, duplicated.Model)
 	assert.Equal(t, versionModel, *duplicated.Model)
+	assert.JSONEq(t, string(modelParams), string(duplicated.ModelParams))
 }
 
-func TestUpdateVersionTemplate_NonDraftRejected(t *testing.T) {
+func TestUpdateVersion_NonDraftRejected(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	v, _ := store.CreateVersion(ctx, p.ID, "original")
+	v, _ := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "original"})
 	store.PromoteVersion(ctx, p.ID, 1) // draft -> stable
 
-	// UpdateVersionTemplate filters by status='draft', so it finds no row.
-	_, err := store.UpdateVersionTemplate(ctx, v.ID, "new content")
+	// UpdateVersion filters by status='draft', so it finds no row.
+	template := "new content"
+	_, err := store.UpdateVersion(ctx, v.ID, store.UpdateVersionParams{Template: &template})
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
 
@@ -218,7 +239,7 @@ func TestPromoteVersion_Lifecycle(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	store.CreateVersion(ctx, p.ID, "template") //nolint:errcheck
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "template"}) //nolint:errcheck
 
 	// Promote 1: draft -> stable
 	v, err := store.PromoteVersion(ctx, p.ID, 1)
@@ -241,13 +262,13 @@ func TestPromoteVersion_DemotesPreviousLive(t *testing.T) {
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
-	store.CreateVersion(ctx, p.ID, "v1") //nolint:errcheck
-	store.PromoteVersion(ctx, p.ID, 1)   // draft -> stable
-	store.PromoteVersion(ctx, p.ID, 1)   // stable -> live
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v1"}) //nolint:errcheck
+	store.PromoteVersion(ctx, p.ID, 1)                                        // draft -> stable
+	store.PromoteVersion(ctx, p.ID, 1)                                        // stable -> live
 
-	store.CreateVersion(ctx, p.ID, "v2") //nolint:errcheck
-	store.PromoteVersion(ctx, p.ID, 2)   // draft -> stable
-	store.PromoteVersion(ctx, p.ID, 2)   // stable -> live
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v2"}) //nolint:errcheck
+	store.PromoteVersion(ctx, p.ID, 2)                                        // draft -> stable
+	store.PromoteVersion(ctx, p.ID, 2)                                        // stable -> live
 
 	v1, err := store.GetVersion(ctx, p.ID, 1)
 	require.NoError(t, err)
@@ -271,7 +292,7 @@ func TestDemoteVersion_Success(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	store.CreateVersion(ctx, p.ID, "v1")
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v1"})
 	store.PromoteVersion(ctx, p.ID, 1) // draft -> stable
 	store.PromoteVersion(ctx, p.ID, 1) // stable -> live
 
@@ -288,7 +309,7 @@ func TestArchiveVersion_Success(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
-	store.CreateVersion(ctx, p.ID, "v1")
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v1"})
 
 	// Archive directly from draft (allowed based on non-archived status)
 	v, err := store.ArchiveVersion(ctx, p.ID, 1)
@@ -305,7 +326,7 @@ func TestDeleteVersion_Success(t *testing.T) {
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
-	v, err := store.CreateVersion(ctx, p.ID, "draft to delete")
+	v, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "draft to delete"})
 	require.NoError(t, err)
 
 	err = store.DeleteVersion(ctx, p.ID, v.Version)
@@ -329,7 +350,7 @@ func TestDeleteVersion_Unified(t *testing.T) {
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
-	store.CreateVersion(ctx, p.ID, "v1")
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v1"})
 	store.PromoteVersion(ctx, p.ID, 1) // draft -> stable
 	store.PromoteVersion(ctx, p.ID, 1) // stable -> live
 
@@ -340,7 +361,7 @@ func TestDeleteVersion_Unified(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, model.VersionStatusArchived, v1.Status) // soft-archived!
 
-	store.CreateVersion(ctx, p.ID, "v2")
+	store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "v2"})
 	store.PromoteVersion(ctx, p.ID, 2) // draft -> stable
 
 	err = store.DeleteVersion(ctx, p.ID, 2) // stable version
@@ -356,7 +377,7 @@ func TestDuplicateVersion(t *testing.T) {
 	ctx := context.Background()
 	p := newPrompt(t, ctx)
 
-	v1, err := store.CreateVersion(ctx, p.ID, "original template content")
+	v1, err := store.CreateVersion(ctx, p.ID, store.CreateVersionParams{Template: "original template content"})
 	require.NoError(t, err)
 
 	// Set a tag on v1 to ensure tag is NOT copied

--- a/internal/store/version_test.go
+++ b/internal/store/version_test.go
@@ -39,6 +39,23 @@ func TestCreateVersion(t *testing.T) {
 	assert.Equal(t, 2, v2.Version)
 }
 
+func TestCreateVersionWithModel(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	p := newPrompt(t, ctx)
+
+	versionModel := "gpt-4.1"
+	v, err := store.CreateVersionWithModel(ctx, p.ID, "template content", &versionModel)
+	require.NoError(t, err)
+	require.NotNil(t, v.Model)
+	assert.Equal(t, versionModel, *v.Model)
+
+	got, err := store.GetVersion(ctx, p.ID, v.Version)
+	require.NoError(t, err)
+	require.NotNil(t, got.Model)
+	assert.Equal(t, versionModel, *got.Model)
+}
+
 func TestListVersions(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
@@ -153,6 +170,36 @@ func TestUpdateVersionTemplate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "updated", updated.Template)
 	assert.Equal(t, model.VersionStatusDraft, updated.Status)
+}
+
+func TestUpdateVersionModel(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	p := newPrompt(t, ctx)
+	v, err := store.CreateVersion(ctx, p.ID, "original")
+	require.NoError(t, err)
+
+	versionModel := "gpt-4.1-mini"
+	updated, err := store.UpdateVersionDraft(ctx, v.ID, nil, &versionModel)
+	require.NoError(t, err)
+	assert.Equal(t, "original", updated.Template)
+	require.NotNil(t, updated.Model)
+	assert.Equal(t, versionModel, *updated.Model)
+}
+
+func TestDuplicateVersionCopiesModel(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	p := newPrompt(t, ctx)
+	versionModel := "gpt-4.1"
+	_, err := store.CreateVersionWithModel(ctx, p.ID, "original", &versionModel)
+	require.NoError(t, err)
+
+	duplicated, err := store.DuplicateVersion(ctx, p.ID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "original", duplicated.Template)
+	require.NotNil(t, duplicated.Model)
+	assert.Equal(t, versionModel, *duplicated.Model)
 }
 
 func TestUpdateVersionTemplate_NonDraftRejected(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds model configuration to prompt versions so the execution model and its provider-specific parameters are versioned with the template.

Closes #5.

## What changed

- Adds nullable `model` and `model_params` columns to `prompt_versions`.
- Stores `model_params` as JSONB to support nested provider-specific settings.
- Supports model configuration in version create and draft update requests.
- Returns model configuration from version and render APIs.
- Copies model configuration when duplicating a version.
- Simplifies the store API to one create function and one update function.
- Updates the OpenAPI source files and bundled specification.

## Validation

- `make spec-bundle`
- `git diff --check`
- `go vet ./...`
- `go test ./internal/store ./internal/handler -run 'Test(CreateVersion|UpdateVersion|DuplicateVersion|RenderLive|GetVersion)' -count=1 -v`
- `go test -race -count=1 -p 1 ./...`

Database-backed tests were discovered but skipped because PostgreSQL is unavailable in the local environment, following the repository test setup.