### PR TITLE
Fail renders with missing template variables

### DIFF
--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -2283,10 +2283,12 @@ paths:
       x-edge-cases:
         - Fails with 404 if no live version is found.
         - Fails with 422 if template execution fails due to invalid parameters or template syntax mismatches.
+        - Fails with 422 when the template references a variable that is not present in the request variables.
       x-test-coverage:
         - 'TestRenderLive_Success: Verifies rendering with complete variables returning 200 OK.'
         - 'TestRenderLive_NoLiveVersion: Verifies that requesting a render with only ''draft'' versions fails with 404 and ''no live version found for this prompt''.'
         - 'TestRenderLive_NoVariables: Verifies static templates render correctly when empty variables are supplied.'
+        - 'TestRenderLive_MissingVariable: Verifies missing template variables fail with 422 instead of rendering placeholder text.'
       requestBody:
         required: true
         content:
@@ -3001,8 +3003,11 @@ paths:
           description: Version sequence number (integer) or version tag (string) to render.
           schema:
             type: string
+      x-edge-cases:
+        - Fails with 422 when the template references a variable that is not present in the request variables.
       x-test-coverage:
         - 'TestRenderVersion_Draft: Verifies that rendering works on draft templates.'
+        - 'TestRenderVersion_MissingVariable: Verifies missing template variables fail with 422 for explicit version renders.'
         - 'TestRenderVersion_NotFound: Verifies 404 response if the requested version sequence number does not exist.'
       requestBody:
         required: true

--- a/docs/openapi/prompt-renders.yaml
+++ b/docs/openapi/prompt-renders.yaml
@@ -22,10 +22,12 @@ paths:
       x-edge-cases:
         - "Fails with 404 if no live version is found."
         - "Fails with 422 if template execution fails due to invalid parameters or template syntax mismatches."
+        - "Fails with 422 when the template references a variable that is not present in the request variables."
       x-test-coverage:
         - "TestRenderLive_Success: Verifies rendering with complete variables returning 200 OK."
         - "TestRenderLive_NoLiveVersion: Verifies that requesting a render with only 'draft' versions fails with 404 and 'no live version found for this prompt'."
         - "TestRenderLive_NoVariables: Verifies static templates render correctly when empty variables are supplied."
+        - "TestRenderLive_MissingVariable: Verifies missing template variables fail with 422 instead of rendering placeholder text."
       requestBody:
         required: true
         content:
@@ -105,8 +107,11 @@ paths:
           description: Version sequence number (integer) or version tag (string) to render.
           schema:
             type: string
+      x-edge-cases:
+        - "Fails with 422 when the template references a variable that is not present in the request variables."
       x-test-coverage:
         - "TestRenderVersion_Draft: Verifies that rendering works on draft templates."
+        - "TestRenderVersion_MissingVariable: Verifies missing template variables fail with 422 for explicit version renders."
         - "TestRenderVersion_NotFound: Verifies 404 response if the requested version sequence number does not exist."
       requestBody:
         required: true

--- a/internal/handler/render.go
+++ b/internal/handler/render.go
@@ -85,7 +85,7 @@ func executeRender(c *fiber.Ctx, prompt *model.Prompt, version *model.PromptVers
 		req.Variables = map[string]any{}
 	}
 
-	tmpl, err := template.New("prompt").Parse(version.Template)
+	tmpl, err := template.New("prompt").Option("missingkey=error").Parse(version.Template)
 	if err != nil {
 		return apierr.ErrTemplateParseError.Respond(c, err)
 	}

--- a/internal/handler/render_test.go
+++ b/internal/handler/render_test.go
@@ -93,6 +93,38 @@ func TestRenderLive_NoVariables(t *testing.T) {
 	assert.Equal(t, "Static prompt with no variables.", body["rendered"])
 }
 
+func TestRenderLive_MissingVariable(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	id := setupPrompt(t, a, token)
+	slug := getPromptSlug(t, a, id, token)
+	setupVersion(t, a, token, id, "Hello, {{.name}}!")
+
+	req := newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	req = newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	req = newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/render", slug),
+		`{"variables":{}}`, token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	errMsg, ok := body["error"].(string)
+	require.True(t, ok)
+	assert.Contains(t, errMsg, "template execution failed")
+}
+
 func TestRenderVersion_Draft(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
@@ -109,6 +141,26 @@ func TestRenderVersion_Draft(t *testing.T) {
 
 	body := decodeBody(t, resp)
 	assert.Equal(t, "Draft: hello", body["rendered"])
+}
+
+func TestRenderVersion_MissingVariable(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	id := setupPrompt(t, a, token)
+	slug := getPromptSlug(t, a, id, token)
+	setupVersion(t, a, token, id, "Draft: {{.msg}}")
+
+	req := newReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/prompts/%s/versions/1/render", slug),
+		`{"variables":{}}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	errMsg, ok := body["error"].(string)
+	require.True(t, ok)
+	assert.Contains(t, errMsg, "template execution failed")
 }
 
 func TestRenderVersion_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Renders now fail when a template references a variable that was not supplied by the caller.

Previously, Go templates rendered missing map keys as `<no value>`, which could silently produce invalid prompts. This change makes missing variables return the existing 422 template execution error instead.

## What changed

- Enables `missingkey=error` for prompt rendering.
- Adds regression coverage for both live renders and explicit version renders.
- Updates the OpenAPI render docs and bundled spec to document the 422 behavior.

## Validation

- `make spec-bundle`
- `git diff --check`
- `go test ./internal/handler -run 'TestRender(Live|Version)' -count=1 -v`
- `go test -race -count=1 -p 1 ./...`

`make check` currently stops at existing lint findings outside this change, mostly unchecked `Close` calls in older tests/loadtest code, an unused telemetry variable, and an existing ineffectual assignment in metrics middleware.
