### PR TITLE
Add configurable search layer with PostgreSQL FTS for Prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,17 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # User Verification & Admin Access
 RESEND_API_KEY=your_resend_api_key_here
 RESEND_FROM_EMAIL=onboarding@resend.dev
+
+# Search Provider
+# Options: postgres (default), elasticsearch, opensearch, algolia
+SEARCH_PROVIDER=postgres
+
+# Elasticsearch / OpenSearch (only required when SEARCH_PROVIDER=elasticsearch or opensearch)
+# ELASTICSEARCH_URL=http://localhost:9200
+# ELASTICSEARCH_API_KEY=your_api_key_here
+# ELASTICSEARCH_INDEX=px0_prompts
+
+# Algolia (only required when SEARCH_PROVIDER=algolia)
+# ALGOLIA_APP_ID=your_app_id_here
+# ALGOLIA_API_KEY=your_api_key_here
+# ALGOLIA_INDEX_NAME=px0_prompts

--- a/.env.example
+++ b/.env.example
@@ -8,16 +8,47 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 RESEND_API_KEY=your_resend_api_key_here
 RESEND_FROM_EMAIL=onboarding@resend.dev
 
-# Search Provider
-# Options: postgres (default), elasticsearch, opensearch, algolia
-SEARCH_PROVIDER=postgres
+# Search Providers
+# Two independent slots: one for FTS, one for vector. Either or both may
+# be set; unset slots default to a no-op provider.
+#
+# FTS options: postgres (default), elasticsearch, opensearch, algolia
+# Vector options: qdrant, pinecone
+#
+# The legacy single SEARCH_PROVIDER env var is still honoured for
+# backward compatibility (postgres -> FTS, qdrant -> vector) but is
+# deprecated; please migrate.
+SEARCH_FTS_PROVIDER=postgres
+# SEARCH_VECTOR_PROVIDER=qdrant
 
-# Elasticsearch / OpenSearch (only required when SEARCH_PROVIDER=elasticsearch or opensearch)
+# Deprecated: single-provider config, supported via the deprecation
+# fallback described in internal/searchfactory/factory.go.
+# SEARCH_PROVIDER=postgres
+
+# Embedder Provider
+# Options: huggingface, openai (coming soon), cohere (coming soon)
+# Leave empty to disable embeddings
+EMBEDDER_PROVIDER=huggingface
+
+# HuggingFace (only required when EMBEDDER_PROVIDER=huggingface)
+# HF_TOKEN=your_token_here
+
+# Elasticsearch / OpenSearch (only required when SEARCH_FTS_PROVIDER is elasticsearch/opensearch)
 # ELASTICSEARCH_URL=http://localhost:9200
-# ELASTICSEARCH_API_KEY=your_api_key_here
+# ELASTICSEARCH_API_KEY=your_key_here
 # ELASTICSEARCH_INDEX=px0_prompts
 
-# Algolia (only required when SEARCH_PROVIDER=algolia)
+# Qdrant (only required when SEARCH_VECTOR_PROVIDER=qdrant)
+# QDRANT_HOST=localhost
+# QDRANT_PORT=6334
+# QDRANT_VECTOR_SIZE=384
+# QDRANT_COLLECTION=px0_prompts
+
+# Algolia (only required when SEARCH_FTS_PROVIDER=algolia)
 # ALGOLIA_APP_ID=your_app_id_here
 # ALGOLIA_API_KEY=your_api_key_here
 # ALGOLIA_INDEX_NAME=px0_prompts
+
+# Pinecone (only required when SEARCH_VECTOR_PROVIDER=pinecone, coming soon)
+# PINECONE_API_KEY=your_key_here
+# PINECONE_INDEX=px0_prompts

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tmp/
 .env
 *.test
 *.out
+.agents/
+*.exe
+test-output.txt

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/px0-ai/px0/internal/app"
 	"github.com/px0-ai/px0/internal/db"
+	"github.com/px0-ai/px0/internal/embedderfactory"
 	"github.com/px0-ai/px0/internal/rdb"
 	"github.com/px0-ai/px0/internal/search"
 	"github.com/px0-ai/px0/internal/searchfactory"
@@ -43,11 +44,26 @@ func main() {
 	}
 	defer rdb.Close()
 
-	if p, err := searchfactory.NewProvider(ctx); err != nil {
-		log.Printf("warn: search provider unavailable, search is disabled: %v", err)
-	} else {
-		search.Init(p)
+	// 3. Initialize embedder provider
+	embedder, err := embedderfactory.NewEmbedder()
+	if err != nil {
+		log.Printf("warn: embedder provider unavailable: %v", err)
+	} else if embedder != nil {
+		search.SetEmbedder(embedder)
 	}
+
+	// 4. Initialize search providers (FTS and vector, independent).
+	ftsProvider, err := searchfactory.NewFTSProvider(ctx)
+	if err != nil {
+		log.Printf("warn: FTS search provider unavailable, FTS search is disabled: %v", err)
+		ftsProvider = search.NoopProvider{}
+	}
+	vectorProvider, err := searchfactory.NewVectorProvider(ctx)
+	if err != nil {
+		log.Printf("warn: vector search provider unavailable, vector search is disabled: %v", err)
+		vectorProvider = search.NoopProvider{}
+	}
+	search.Init(ftsProvider, vectorProvider)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/px0-ai/px0/internal/app"
 	"github.com/px0-ai/px0/internal/db"
 	"github.com/px0-ai/px0/internal/rdb"
+	"github.com/px0-ai/px0/internal/search"
+	"github.com/px0-ai/px0/internal/searchfactory"
 	"github.com/px0-ai/px0/internal/telemetry"
 )
 
@@ -40,6 +42,12 @@ func main() {
 		log.Printf("warn: redis unavailable, sessions will not be cached: %v", err)
 	}
 	defer rdb.Close()
+
+	if p, err := searchfactory.NewProvider(ctx); err != nil {
+		log.Printf("warn: search provider unavailable, search is disabled: %v", err)
+	} else {
+		search.Init(p)
+	}
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,5 +103,16 @@ services:
       - prometheus
     restart: unless-stopped
 
+  qdrant:
+    image: qdrant/qdrant
+    container_name: qdrant
+    ports:
+      - "6333:6333" # HTTP API
+      - "6334:6334" # gRPC API
+    volumes:
+      - qdrant_storage:/qdrant/storage:z
+    restart: always
+
 volumes:
   postgres_data:
+  qdrant_storage:

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -1732,6 +1732,20 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+        - name: q
+          in: query
+          required: false
+          description: |
+            Full-text search query. When provided, results are filtered and ranked by relevance across prompt name, description, and slug using PostgreSQL Full-Text Search. When absent, returns the unranked list.
+          schema:
+            type: string
+            example: summarize text
+      x-edge-cases:
+        - When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour.
+        - When ?q= is present and no results match, returns an empty array (not 404).
+        - Tags filtering at list endpoints is not part of the current API contract (out of scope).
+        - Pagination is deferred — no Limit/Offset/TotalCount yet.
+        - Score is internal-only; not exposed in the API response.
       x-test-coverage:
         - 'TestListPrompts: Verifies listing populated prompt containers.'
         - 'TestListPrompts_Empty: Verifies that listing when empty returns an empty array.'
@@ -1795,9 +1809,22 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+        - name: q
+          in: query
+          required: false
+          description: |
+            Full-text search query. When provided, results are filtered and ranked by relevance across prompt name, description, and slug using PostgreSQL Full-Text Search. When absent, returns the unranked list.
+          schema:
+            type: string
+            example: summarize text
       x-edge-cases:
         - By default with no team_id query parameter, returns an empty list of prompts.
         - If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden.
+        - When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour.
+        - When ?q= is present and no results match, returns an empty array (not 404).
+        - Tags filtering at list endpoints is not part of the current API contract (out of scope).
+        - Pagination is deferred — no Limit/Offset/TotalCount yet.
+        - Score is internal-only; not exposed in the API response.
       x-test-coverage:
         - 'TestListAllPrompts: Verifies that no team_id returns 200 with an empty list.'
         - 'TestListAllPrompts: Verifies that a valid team_id returns 200 with prompts of that team.'

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -2016,6 +2016,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
+    delete:
+      summary: Delete a Prompt
+      description: Hard deletes a specific prompt by its unique UUID.
+      operationId: deletePrompt
+      tags:
+        - Prompts
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique UUID of the prompt.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - 'Forbidden: Attempting to delete a prompt with viewer permissions.'
+        - 'NotFound: Attempting to delete a non-existent prompt ID or a prompt under an unauthorized team.'
+      x-test-coverage:
+        - 'TestDeletePrompt_Success: Verifies deleting with editor token.'
+        - 'TestDeletePrompt_ViewerForbidden: Verifies viewer gets a 403 response.'
+        - 'TestDeletePrompt_NotFound: Verifies 404 response on missing prompt ID.'
+      responses:
+        '204':
+          description: Prompt deleted successfully
+        '400':
+          description: Invalid input or invalid UUID format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Forbidden - Viewer or unauthorized team member
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Prompt not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /v1/prompts/{id}/archive:
     post:
       summary: Archive a Prompt

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -1726,6 +1726,18 @@ paths:
             type: string
             format: uuid
           description: The ID of the team.
+        - name: mode
+          in: query
+          required: false
+          description: |
+            Search mode. "fts" (default) uses full-text search against the tsvector column. "vector" requires a pre-computed ?vector= or a query embedder for ?q=. "hybrid" combines FTS and vector ranking (not yet implemented — returns 501). Unknown values return 400. Defaults to "fts" when absent; callers that omit ?mode= but supply a raw ?vector= are routed to "vector" for backwards compatibility.
+          schema:
+            type: string
+            enum:
+              - fts
+              - vector
+              - hybrid
+            default: fts
         - name: archived
           in: query
           required: false
@@ -1736,7 +1748,7 @@ paths:
           in: query
           required: false
           description: |
-            Full-text search query. When provided, results are filtered and ranked by relevance across prompt name, description, and slug using PostgreSQL Full-Text Search. When absent, returns the unranked list.
+            Full-text search query. When provided under ?mode=fts (or when ?mode= is absent), results are filtered and ranked by relevance across prompt name (weight A), description (weight B), and slug (weight C) using PostgreSQL Full-Text Search. An empty ?q= short-circuits to an empty result set rather than relying on websearch_to_tsquery(''). When ?mode=vector is requested without a ?vector=, the embedder is used to embed ?q=.
           schema:
             type: string
             example: summarize text
@@ -1744,7 +1756,7 @@ paths:
           in: query
           required: false
           description: |
-            Pre-computed query embedding for vector-similarity search, expressed as a comma-separated list of float32 values (e.g. "0.12,0.45,0.98"). When provided, results are ranked by vector distance instead of FTS score. Mutually exclusive with ?q= — if both are sent, vector takes precedence. Returns 400 if the active search provider does not support vector search.
+            Pre-computed query embedding for vector-similarity search, expressed as a comma-separated list of float32 values (e.g. "0.12,0.45,0.98"). When provided, results are ranked by vector distance. With ?mode=vector, returns 400 if the value cannot be parsed and 501 if the active search provider does not support vector search.
           schema:
             type: string
             example: 0.12,0.45,0.98
@@ -1752,24 +1764,40 @@ paths:
           in: query
           required: false
           description: |
-            Maximum number of results to return when using vector search (default: 10). Ignored for full-text search and listing paths.
+            Maximum number of results to return when using vector search (default: 10). Also caps the FTS results when ?mode=fts is requested with a ?q=.
           schema:
             type: integer
             default: 10
             minimum: 1
             maximum: 100
       x-edge-cases:
-        - When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour.
+        - When ?q= is absent and ?mode=fts, returns the unranked listing (no FTS).
+        - When ?q= is present and ?mode=fts, returns FTS results ranked by ts_rank with a minimum-rank threshold.
+        - When ?q= is empty, the FTS path short-circuits to an empty result set (not relying on websearch_to_tsquery('')).
         - When ?q= is present and no results match, returns an empty array (not 404).
-        - When ?vector= is present but the active provider does not support vector search, returns 400.
-        - When both ?q= and ?vector= are present, ?vector= takes precedence.
-        - '?top_k= is only applied during vector search; ignored for FTS or listing.'
+        - When ?mode=vector with neither ?vector= nor ?q=, returns 400.
+        - When ?mode=vector with a ?q= but no embedder configured, returns 501 (no silent alias to FTS).
+        - When ?mode=vector with a ?q= and embedder present but embedding fails, returns 501 with the embedder error in the body.
+        - When ?mode=vector with a ?vector= but no vector-capable provider active, returns 501.
+        - When ?mode=hybrid, returns 501 (not yet implemented).
+        - When ?mode= is an unknown value, returns 400.
+        - 'Backwards-compat: callers that omit ?mode= but supply ?vector= are routed to ?mode=vector.'
+        - '?top_k= caps FTS results too, not just vector results.'
         - Tags filtering at list endpoints is not part of the current API contract (out of scope).
         - Pagination is deferred — no Limit/Offset/TotalCount yet.
+        - The response always includes an 'engine' field identifying the path that served the request (fts, vector, or hybrid).
         - Score is internal-only; not exposed in the API response.
       x-test-coverage:
         - 'TestListPrompts: Verifies listing populated prompt containers.'
         - 'TestListPrompts_Empty: Verifies that listing when empty returns an empty array.'
+        - 'TestListPrompts_EngineFieldDefault: Verifies that a no-arg list returns engine=fts.'
+        - 'TestListPrompts_InvalidMode: Verifies that ?mode=bogus returns 400.'
+        - 'TestListPrompts_ModeHybridReturns501: Verifies that ?mode=hybrid returns 501.'
+        - 'TestListPrompts_ModeVectorNoQueryNoVector: Verifies that ?mode=vector with no input returns 400.'
+        - 'TestListPrompts_ModeVectorNoEmbedder: Verifies that ?mode=vector with ?q= and no embedder returns 501.'
+        - 'TestListPrompts_VectorUnsupportedProvider: Verifies that a vector request with a NoopProvider returns 501, not a silent fallthrough.'
+        - 'TestListPrompts_InvalidVector: Verifies that an unparseable ?vector= returns 400.'
+        - 'TestSearchPrompts_FTS: Verifies real tsvector FTS ranking with name (A) > description (B) > slug (C) weights.'
       responses:
         '200':
           description: List of prompts
@@ -1782,18 +1810,34 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Prompt'
+                  engine:
+                    type: string
+                    enum:
+                      - fts
+                      - vector
+                      - hybrid
+                    description: |
+                      Identifies which ranking path actually served the request. Always present so clients (and tests) can verify the mode they requested is the mode that ran.
+                    example: fts
                 required:
                   - prompts
+                  - engine
         '400':
-          description: Bad request (invalid vector param or unsupported)
+          description: Bad request (invalid mode, invalid vector param, or missing input for the chosen mode)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
               examples:
+                invalid_mode:
+                  value:
+                    error: "invalid mode: must be one of 'fts', 'vector', 'hybrid'"
                 invalid_vector:
                   value:
                     error: 'invalid vector parameter: invalid value "abc"'
+                vector_requires_input:
+                  value:
+                    error: vector mode requires either vector= or q= parameter
                 unsupported_provider:
                   value:
                     error: vector search not supported by the active search provider
@@ -1813,6 +1857,28 @@ paths:
                 $ref: '#/components/schemas/APIError'
               example:
                 error: internal error
+        '501':
+          description: Not implemented (vector/hybrid unavailable, or active provider cannot honour the requested mode)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              examples:
+                hybrid_unsupported:
+                  value:
+                    error: hybrid search not implemented
+                vector_no_embedder:
+                  value:
+                    error: 'vector search unavailable: no embedder configured (set EMBEDDER_PROVIDER and HF_TOKEN)'
+                vector_embed_failed:
+                  value:
+                    error: 'vector search unavailable: embedding failed: hf: status 503'
+                fts_not_supported:
+                  value:
+                    error: fts search not implemented by the active search provider
+                vector_not_supported:
+                  value:
+                    error: vector search not implemented by the active search provider
   /v1/prompts:
     get:
       summary: List all prompts with team filter
@@ -1837,6 +1903,18 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: mode
+          in: query
+          required: false
+          description: |
+            Search mode. Same semantics as on /v1/teams/{teamID}/prompts. "fts" (default) uses PostgreSQL FTS, "vector" requires an embedder or pre-computed ?vector=, "hybrid" returns 501.
+          schema:
+            type: string
+            enum:
+              - fts
+              - vector
+              - hybrid
+            default: fts
         - name: archived
           in: query
           required: false
@@ -1847,7 +1925,7 @@ paths:
           in: query
           required: false
           description: |
-            Full-text search query. When provided, results are filtered and ranked by relevance across prompt name, description, and slug using PostgreSQL Full-Text Search. When absent, returns the unranked list.
+            Full-text search query. See /v1/teams/{teamID}/prompts for semantics; same weight ordering and same short-circuit behaviour for empty values.
           schema:
             type: string
             example: summarize text
@@ -1855,7 +1933,7 @@ paths:
           in: query
           required: false
           description: |
-            Pre-computed query embedding for vector-similarity search, expressed as a comma-separated list of float32 values (e.g. "0.12,0.45,0.98"). When provided, results are ranked by vector distance instead of FTS score. Mutually exclusive with ?q= — if both are sent, vector takes precedence. Returns 400 if the active search provider does not support vector search.
+            Pre-computed query embedding for vector-similarity search. See /v1/teams/{teamID}/prompts for full semantics.
           schema:
             type: string
             example: 0.12,0.45,0.98
@@ -1863,27 +1941,28 @@ paths:
           in: query
           required: false
           description: |
-            Maximum number of results to return when using vector search (default: 10). Ignored for full-text search and listing paths.
+            Maximum number of results to return when using vector search (default: 10). Also caps FTS results.
           schema:
             type: integer
             default: 10
             minimum: 1
             maximum: 100
       x-edge-cases:
-        - By default with no team_id query parameter, returns an empty list of prompts.
+        - By default with no team_id query parameter, returns an empty list of prompts (engine=fts).
         - If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden.
-        - When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour.
+        - When ?q= is absent and ?mode=fts, returns the unranked listing.
+        - When ?q= is present and ?mode=fts, returns FTS results ranked by ts_rank with a minimum-rank threshold.
+        - When ?q= is empty, the FTS path short-circuits to an empty result set.
         - When ?q= is present and no results match, returns an empty array (not 404).
-        - When ?vector= is present but the active provider does not support vector search, returns 400.
-        - When both ?q= and ?vector= are present, ?vector= takes precedence.
-        - '?top_k= is only applied during vector search; ignored for FTS or listing.'
-        - Tags filtering at list endpoints is not part of the current API contract (out of scope).
+        - When ?mode=vector, ?mode=hybrid, or other unavailable modes, returns the same 4xx/5xx as on the team-scoped endpoint.
+        - '?top_k= caps FTS results too, not just vector results.'
+        - The response always includes an 'engine' field identifying the path that served the request.
         - Pagination is deferred — no Limit/Offset/TotalCount yet.
-        - Score is internal-only; not exposed in the API response.
       x-test-coverage:
-        - 'TestListAllPrompts: Verifies that no team_id returns 200 with an empty list.'
+        - 'TestListAllPrompts: Verifies that no team_id returns 200 with an empty list and engine=fts.'
         - 'TestListAllPrompts: Verifies that a valid team_id returns 200 with prompts of that team.'
         - 'TestListAllPrompts: Verifies that an unallowed team_id returns 403 Forbidden.'
+        - 'TestListAllPrompts_EngineField: Verifies that the response always includes engine=fts.'
       responses:
         '200':
           description: A list of prompts
@@ -1896,16 +1975,34 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Prompt'
+                  engine:
+                    type: string
+                    enum:
+                      - fts
+                      - vector
+                      - hybrid
+                    description: |
+                      Identifies which ranking path actually served the request. Always present.
+                    example: fts
+                required:
+                  - prompts
+                  - engine
         '400':
-          description: Bad request (invalid vector param or unsupported)
+          description: Bad request (invalid mode, invalid vector param, or missing input for the chosen mode)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
               examples:
+                invalid_mode:
+                  value:
+                    error: "invalid mode: must be one of 'fts', 'vector', 'hybrid'"
                 invalid_vector:
                   value:
                     error: 'invalid vector parameter: invalid value "abc"'
+                vector_requires_input:
+                  value:
+                    error: vector mode requires either vector= or q= parameter
                 unsupported_provider:
                   value:
                     error: vector search not supported by the active search provider

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -1740,9 +1740,30 @@ paths:
           schema:
             type: string
             example: summarize text
+        - name: vector
+          in: query
+          required: false
+          description: |
+            Pre-computed query embedding for vector-similarity search, expressed as a comma-separated list of float32 values (e.g. "0.12,0.45,0.98"). When provided, results are ranked by vector distance instead of FTS score. Mutually exclusive with ?q= — if both are sent, vector takes precedence. Returns 400 if the active search provider does not support vector search.
+          schema:
+            type: string
+            example: 0.12,0.45,0.98
+        - name: top_k
+          in: query
+          required: false
+          description: |
+            Maximum number of results to return when using vector search (default: 10). Ignored for full-text search and listing paths.
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 100
       x-edge-cases:
         - When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour.
         - When ?q= is present and no results match, returns an empty array (not 404).
+        - When ?vector= is present but the active provider does not support vector search, returns 400.
+        - When both ?q= and ?vector= are present, ?vector= takes precedence.
+        - '?top_k= is only applied during vector search; ignored for FTS or listing.'
         - Tags filtering at list endpoints is not part of the current API contract (out of scope).
         - Pagination is deferred — no Limit/Offset/TotalCount yet.
         - Score is internal-only; not exposed in the API response.
@@ -1763,6 +1784,19 @@ paths:
                       $ref: '#/components/schemas/Prompt'
                 required:
                   - prompts
+        '400':
+          description: Bad request (invalid vector param or unsupported)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              examples:
+                invalid_vector:
+                  value:
+                    error: 'invalid vector parameter: invalid value "abc"'
+                unsupported_provider:
+                  value:
+                    error: vector search not supported by the active search provider
         '401':
           description: Unauthorized
           content:
@@ -1817,11 +1851,32 @@ paths:
           schema:
             type: string
             example: summarize text
+        - name: vector
+          in: query
+          required: false
+          description: |
+            Pre-computed query embedding for vector-similarity search, expressed as a comma-separated list of float32 values (e.g. "0.12,0.45,0.98"). When provided, results are ranked by vector distance instead of FTS score. Mutually exclusive with ?q= — if both are sent, vector takes precedence. Returns 400 if the active search provider does not support vector search.
+          schema:
+            type: string
+            example: 0.12,0.45,0.98
+        - name: top_k
+          in: query
+          required: false
+          description: |
+            Maximum number of results to return when using vector search (default: 10). Ignored for full-text search and listing paths.
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 100
       x-edge-cases:
         - By default with no team_id query parameter, returns an empty list of prompts.
         - If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden.
         - When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour.
         - When ?q= is present and no results match, returns an empty array (not 404).
+        - When ?vector= is present but the active provider does not support vector search, returns 400.
+        - When both ?q= and ?vector= are present, ?vector= takes precedence.
+        - '?top_k= is only applied during vector search; ignored for FTS or listing.'
         - Tags filtering at list endpoints is not part of the current API contract (out of scope).
         - Pagination is deferred — no Limit/Offset/TotalCount yet.
         - Score is internal-only; not exposed in the API response.
@@ -1841,6 +1896,19 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Prompt'
+        '400':
+          description: Bad request (invalid vector param or unsupported)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              examples:
+                invalid_vector:
+                  value:
+                    error: 'invalid vector parameter: invalid value "abc"'
+                unsupported_provider:
+                  value:
+                    error: vector search not supported by the active search provider
         '401':
           description: Unauthorized
           content:

--- a/docs/openapi/prompts.yaml
+++ b/docs/openapi/prompts.yaml
@@ -92,6 +92,22 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+        - name: q
+          in: query
+          required: false
+          description: >
+            Full-text search query. When provided, results are filtered and ranked
+            by relevance across prompt name, description, and slug using
+            PostgreSQL Full-Text Search. When absent, returns the unranked list.
+          schema:
+            type: string
+            example: "summarize text"
+      x-edge-cases:
+        - "When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour."
+        - "When ?q= is present and no results match, returns an empty array (not 404)."
+        - "Tags filtering at list endpoints is not part of the current API contract (out of scope)."
+        - "Pagination is deferred — no Limit/Offset/TotalCount yet."
+        - "Score is internal-only; not exposed in the API response."
       x-test-coverage:
         - "TestListPrompts: Verifies listing populated prompt containers."
         - "TestListPrompts_Empty: Verifies that listing when empty returns an empty array."
@@ -156,9 +172,24 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+        - name: q
+          in: query
+          required: false
+          description: >
+            Full-text search query. When provided, results are filtered and ranked
+            by relevance across prompt name, description, and slug using
+            PostgreSQL Full-Text Search. When absent, returns the unranked list.
+          schema:
+            type: string
+            example: "summarize text"
       x-edge-cases:
         - "By default with no team_id query parameter, returns an empty list of prompts."
         - "If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden."
+        - "When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour."
+        - "When ?q= is present and no results match, returns an empty array (not 404)."
+        - "Tags filtering at list endpoints is not part of the current API contract (out of scope)."
+        - "Pagination is deferred — no Limit/Offset/TotalCount yet."
+        - "Score is internal-only; not exposed in the API response."
       x-test-coverage:
         - "TestListAllPrompts: Verifies that no team_id returns 200 with an empty list."
         - "TestListAllPrompts: Verifies that a valid team_id returns 200 with prompts of that team."

--- a/docs/openapi/prompts.yaml
+++ b/docs/openapi/prompts.yaml
@@ -102,9 +102,35 @@ paths:
           schema:
             type: string
             example: "summarize text"
+        - name: vector
+          in: query
+          required: false
+          description: >
+            Pre-computed query embedding for vector-similarity search, expressed as a
+            comma-separated list of float32 values (e.g. "0.12,0.45,0.98").
+            When provided, results are ranked by vector distance instead of FTS score.
+            Mutually exclusive with ?q= — if both are sent, vector takes precedence.
+            Returns 400 if the active search provider does not support vector search.
+          schema:
+            type: string
+            example: "0.12,0.45,0.98"
+        - name: top_k
+          in: query
+          required: false
+          description: >
+            Maximum number of results to return when using vector search (default: 10).
+            Ignored for full-text search and listing paths.
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 100
       x-edge-cases:
         - "When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour."
         - "When ?q= is present and no results match, returns an empty array (not 404)."
+        - "When ?vector= is present but the active provider does not support vector search, returns 400."
+        - "When both ?q= and ?vector= are present, ?vector= takes precedence."
+        - "?top_k= is only applied during vector search; ignored for FTS or listing."
         - "Tags filtering at list endpoints is not part of the current API contract (out of scope)."
         - "Pagination is deferred — no Limit/Offset/TotalCount yet."
         - "Score is internal-only; not exposed in the API response."
@@ -125,6 +151,17 @@ paths:
                       $ref: "#/components/schemas/Prompt"
                 required:
                   - prompts
+        "400":
+          description: Bad request (invalid vector param or unsupported)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+              examples:
+                invalid_vector:
+                  value: { "error": "invalid vector parameter: invalid value \"abc\"" }
+                unsupported_provider:
+                  value: { "error": "vector search not supported by the active search provider" }
         "401":
           description: Unauthorized
           content:
@@ -182,11 +219,37 @@ paths:
           schema:
             type: string
             example: "summarize text"
+        - name: vector
+          in: query
+          required: false
+          description: >
+            Pre-computed query embedding for vector-similarity search, expressed as a
+            comma-separated list of float32 values (e.g. "0.12,0.45,0.98").
+            When provided, results are ranked by vector distance instead of FTS score.
+            Mutually exclusive with ?q= — if both are sent, vector takes precedence.
+            Returns 400 if the active search provider does not support vector search.
+          schema:
+            type: string
+            example: "0.12,0.45,0.98"
+        - name: top_k
+          in: query
+          required: false
+          description: >
+            Maximum number of results to return when using vector search (default: 10).
+            Ignored for full-text search and listing paths.
+          schema:
+            type: integer
+            default: 10
+            minimum: 1
+            maximum: 100
       x-edge-cases:
         - "By default with no team_id query parameter, returns an empty list of prompts."
         - "If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden."
         - "When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour."
         - "When ?q= is present and no results match, returns an empty array (not 404)."
+        - "When ?vector= is present but the active provider does not support vector search, returns 400."
+        - "When both ?q= and ?vector= are present, ?vector= takes precedence."
+        - "?top_k= is only applied during vector search; ignored for FTS or listing."
         - "Tags filtering at list endpoints is not part of the current API contract (out of scope)."
         - "Pagination is deferred — no Limit/Offset/TotalCount yet."
         - "Score is internal-only; not exposed in the API response."
@@ -206,6 +269,17 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Prompt"
+        "400":
+          description: Bad request (invalid vector param or unsupported)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+              examples:
+                invalid_vector:
+                  value: { "error": "invalid vector parameter: invalid value \"abc\"" }
+                unsupported_provider:
+                  value: { "error": "vector search not supported by the active search provider" }
         "401":
           description: Unauthorized
           content:

--- a/docs/openapi/prompts.yaml
+++ b/docs/openapi/prompts.yaml
@@ -86,6 +86,21 @@ paths:
             type: string
             format: uuid
           description: The ID of the team.
+        - name: mode
+          in: query
+          required: false
+          description: >
+            Search mode. "fts" (default) uses full-text search against the
+            tsvector column. "vector" requires a pre-computed ?vector= or a
+            query embedder for ?q=. "hybrid" combines FTS and vector
+            ranking (not yet implemented — returns 501). Unknown values
+            return 400. Defaults to "fts" when absent; callers that omit
+            ?mode= but supply a raw ?vector= are routed to "vector" for
+            backwards compatibility.
+          schema:
+            type: string
+            enum: [fts, vector, hybrid]
+            default: fts
         - name: archived
           in: query
           required: false
@@ -96,9 +111,14 @@ paths:
           in: query
           required: false
           description: >
-            Full-text search query. When provided, results are filtered and ranked
-            by relevance across prompt name, description, and slug using
-            PostgreSQL Full-Text Search. When absent, returns the unranked list.
+            Full-text search query. When provided under ?mode=fts (or
+            when ?mode= is absent), results are filtered and ranked by
+            relevance across prompt name (weight A), description
+            (weight B), and slug (weight C) using PostgreSQL Full-Text
+            Search. An empty ?q= short-circuits to an empty result
+            set rather than relying on websearch_to_tsquery(''). When
+            ?mode=vector is requested without a ?vector=, the embedder
+            is used to embed ?q=.
           schema:
             type: string
             example: "summarize text"
@@ -106,11 +126,12 @@ paths:
           in: query
           required: false
           description: >
-            Pre-computed query embedding for vector-similarity search, expressed as a
-            comma-separated list of float32 values (e.g. "0.12,0.45,0.98").
-            When provided, results are ranked by vector distance instead of FTS score.
-            Mutually exclusive with ?q= — if both are sent, vector takes precedence.
-            Returns 400 if the active search provider does not support vector search.
+            Pre-computed query embedding for vector-similarity search,
+            expressed as a comma-separated list of float32 values
+            (e.g. "0.12,0.45,0.98"). When provided, results are ranked
+            by vector distance. With ?mode=vector, returns 400 if the
+            value cannot be parsed and 501 if the active search
+            provider does not support vector search.
           schema:
             type: string
             example: "0.12,0.45,0.98"
@@ -118,25 +139,42 @@ paths:
           in: query
           required: false
           description: >
-            Maximum number of results to return when using vector search (default: 10).
-            Ignored for full-text search and listing paths.
+            Maximum number of results to return when using vector
+            search (default: 10). Also caps the FTS results when
+            ?mode=fts is requested with a ?q=.
           schema:
             type: integer
             default: 10
             minimum: 1
             maximum: 100
       x-edge-cases:
-        - "When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour."
+        - "When ?q= is absent and ?mode=fts, returns the unranked listing (no FTS)."
+        - "When ?q= is present and ?mode=fts, returns FTS results ranked by ts_rank with a minimum-rank threshold."
+        - "When ?q= is empty, the FTS path short-circuits to an empty result set (not relying on websearch_to_tsquery(''))."
         - "When ?q= is present and no results match, returns an empty array (not 404)."
-        - "When ?vector= is present but the active provider does not support vector search, returns 400."
-        - "When both ?q= and ?vector= are present, ?vector= takes precedence."
-        - "?top_k= is only applied during vector search; ignored for FTS or listing."
+        - "When ?mode=vector with neither ?vector= nor ?q=, returns 400."
+        - "When ?mode=vector with a ?q= but no embedder configured, returns 501 (no silent alias to FTS)."
+        - "When ?mode=vector with a ?q= and embedder present but embedding fails, returns 501 with the embedder error in the body."
+        - "When ?mode=vector with a ?vector= but no vector-capable provider active, returns 501."
+        - "When ?mode=hybrid, returns 501 (not yet implemented)."
+        - "When ?mode= is an unknown value, returns 400."
+        - "Backwards-compat: callers that omit ?mode= but supply ?vector= are routed to ?mode=vector."
+        - "?top_k= caps FTS results too, not just vector results."
         - "Tags filtering at list endpoints is not part of the current API contract (out of scope)."
         - "Pagination is deferred — no Limit/Offset/TotalCount yet."
+        - "The response always includes an 'engine' field identifying the path that served the request (fts, vector, or hybrid)."
         - "Score is internal-only; not exposed in the API response."
       x-test-coverage:
         - "TestListPrompts: Verifies listing populated prompt containers."
         - "TestListPrompts_Empty: Verifies that listing when empty returns an empty array."
+        - "TestListPrompts_EngineFieldDefault: Verifies that a no-arg list returns engine=fts."
+        - "TestListPrompts_InvalidMode: Verifies that ?mode=bogus returns 400."
+        - "TestListPrompts_ModeHybridReturns501: Verifies that ?mode=hybrid returns 501."
+        - "TestListPrompts_ModeVectorNoQueryNoVector: Verifies that ?mode=vector with no input returns 400."
+        - "TestListPrompts_ModeVectorNoEmbedder: Verifies that ?mode=vector with ?q= and no embedder returns 501."
+        - "TestListPrompts_VectorUnsupportedProvider: Verifies that a vector request with a NoopProvider returns 501, not a silent fallthrough."
+        - "TestListPrompts_InvalidVector: Verifies that an unparseable ?vector= returns 400."
+        - "TestSearchPrompts_FTS: Verifies real tsvector FTS ranking with name (A) > description (B) > slug (C) weights."
       responses:
         "200":
           description: List of prompts
@@ -149,17 +187,30 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Prompt"
+                  engine:
+                    type: string
+                    enum: [fts, vector, hybrid]
+                    description: >
+                      Identifies which ranking path actually served the
+                      request. Always present so clients (and tests) can
+                      verify the mode they requested is the mode that ran.
+                    example: "fts"
                 required:
                   - prompts
+                  - engine
         "400":
-          description: Bad request (invalid vector param or unsupported)
+          description: Bad request (invalid mode, invalid vector param, or missing input for the chosen mode)
           content:
             application/json:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
               examples:
+                invalid_mode:
+                  value: { "error": "invalid mode: must be one of 'fts', 'vector', 'hybrid'" }
                 invalid_vector:
                   value: { "error": "invalid vector parameter: invalid value \"abc\"" }
+                vector_requires_input:
+                  value: { "error": "vector mode requires either vector= or q= parameter" }
                 unsupported_provider:
                   value: { "error": "vector search not supported by the active search provider" }
         "401":
@@ -178,6 +229,23 @@ paths:
                 $ref: "./auth.yaml#/components/schemas/APIError"
               example:
                 error: "internal error"
+        "501":
+          description: Not implemented (vector/hybrid unavailable, or active provider cannot honour the requested mode)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+              examples:
+                hybrid_unsupported:
+                  value: { "error": "hybrid search not implemented" }
+                vector_no_embedder:
+                  value: { "error": "vector search unavailable: no embedder configured (set EMBEDDER_PROVIDER and HF_TOKEN)" }
+                vector_embed_failed:
+                  value: { "error": "vector search unavailable: embedding failed: hf: status 503" }
+                fts_not_supported:
+                  value: { "error": "fts search not implemented by the active search provider" }
+                vector_not_supported:
+                  value: { "error": "vector search not implemented by the active search provider" }
 
   /v1/prompts:
     get:
@@ -203,6 +271,17 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: mode
+          in: query
+          required: false
+          description: >
+            Search mode. Same semantics as on /v1/teams/{teamID}/prompts.
+            "fts" (default) uses PostgreSQL FTS, "vector" requires an
+            embedder or pre-computed ?vector=, "hybrid" returns 501.
+          schema:
+            type: string
+            enum: [fts, vector, hybrid]
+            default: fts
         - name: archived
           in: query
           required: false
@@ -213,9 +292,9 @@ paths:
           in: query
           required: false
           description: >
-            Full-text search query. When provided, results are filtered and ranked
-            by relevance across prompt name, description, and slug using
-            PostgreSQL Full-Text Search. When absent, returns the unranked list.
+            Full-text search query. See /v1/teams/{teamID}/prompts for
+            semantics; same weight ordering and same short-circuit
+            behaviour for empty values.
           schema:
             type: string
             example: "summarize text"
@@ -223,11 +302,8 @@ paths:
           in: query
           required: false
           description: >
-            Pre-computed query embedding for vector-similarity search, expressed as a
-            comma-separated list of float32 values (e.g. "0.12,0.45,0.98").
-            When provided, results are ranked by vector distance instead of FTS score.
-            Mutually exclusive with ?q= — if both are sent, vector takes precedence.
-            Returns 400 if the active search provider does not support vector search.
+            Pre-computed query embedding for vector-similarity search.
+            See /v1/teams/{teamID}/prompts for full semantics.
           schema:
             type: string
             example: "0.12,0.45,0.98"
@@ -235,28 +311,29 @@ paths:
           in: query
           required: false
           description: >
-            Maximum number of results to return when using vector search (default: 10).
-            Ignored for full-text search and listing paths.
+            Maximum number of results to return when using vector
+            search (default: 10). Also caps FTS results.
           schema:
             type: integer
             default: 10
             minimum: 1
             maximum: 100
       x-edge-cases:
-        - "By default with no team_id query parameter, returns an empty list of prompts."
+        - "By default with no team_id query parameter, returns an empty list of prompts (engine=fts)."
         - "If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden."
-        - "When ?q= is absent or empty, falls back to the standard listing path with no change in behaviour."
+        - "When ?q= is absent and ?mode=fts, returns the unranked listing."
+        - "When ?q= is present and ?mode=fts, returns FTS results ranked by ts_rank with a minimum-rank threshold."
+        - "When ?q= is empty, the FTS path short-circuits to an empty result set."
         - "When ?q= is present and no results match, returns an empty array (not 404)."
-        - "When ?vector= is present but the active provider does not support vector search, returns 400."
-        - "When both ?q= and ?vector= are present, ?vector= takes precedence."
-        - "?top_k= is only applied during vector search; ignored for FTS or listing."
-        - "Tags filtering at list endpoints is not part of the current API contract (out of scope)."
+        - "When ?mode=vector, ?mode=hybrid, or other unavailable modes, returns the same 4xx/5xx as on the team-scoped endpoint."
+        - "?top_k= caps FTS results too, not just vector results."
+        - "The response always includes an 'engine' field identifying the path that served the request."
         - "Pagination is deferred — no Limit/Offset/TotalCount yet."
-        - "Score is internal-only; not exposed in the API response."
       x-test-coverage:
-        - "TestListAllPrompts: Verifies that no team_id returns 200 with an empty list."
+        - "TestListAllPrompts: Verifies that no team_id returns 200 with an empty list and engine=fts."
         - "TestListAllPrompts: Verifies that a valid team_id returns 200 with prompts of that team."
         - "TestListAllPrompts: Verifies that an unallowed team_id returns 403 Forbidden."
+        - "TestListAllPrompts_EngineField: Verifies that the response always includes engine=fts."
       responses:
         "200":
           description: A list of prompts
@@ -269,15 +346,29 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Prompt"
+                  engine:
+                    type: string
+                    enum: [fts, vector, hybrid]
+                    description: >
+                      Identifies which ranking path actually served
+                      the request. Always present.
+                    example: "fts"
+                required:
+                  - prompts
+                  - engine
         "400":
-          description: Bad request (invalid vector param or unsupported)
+          description: Bad request (invalid mode, invalid vector param, or missing input for the chosen mode)
           content:
             application/json:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
               examples:
+                invalid_mode:
+                  value: { "error": "invalid mode: must be one of 'fts', 'vector', 'hybrid'" }
                 invalid_vector:
                   value: { "error": "invalid vector parameter: invalid value \"abc\"" }
+                vector_requires_input:
+                  value: { "error": "vector mode requires either vector= or q= parameter" }
                 unsupported_provider:
                   value: { "error": "vector search not supported by the active search provider" }
         "401":
@@ -298,6 +389,19 @@ paths:
             application/json:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
+        "501":
+          description: Not implemented (vector/hybrid unavailable, or active provider cannot honour the requested mode)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+              examples:
+                hybrid_unsupported:
+                  value: { "error": "hybrid search not implemented" }
+                vector_no_embedder:
+                  value: { "error": "vector search unavailable: no embedder configured (set EMBEDDER_PROVIDER and HF_TOKEN)" }
+                vector_not_supported:
+                  value: { "error": "vector search not implemented by the active search provider" }
 
   /v1/prompts/{id}:
     get:

--- a/docs/openapi/prompts.yaml
+++ b/docs/openapi/prompts.yaml
@@ -382,6 +382,62 @@ paths:
             application/json:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
+    delete:
+      summary: Delete a Prompt
+      description: Hard deletes a specific prompt by its unique UUID.
+      operationId: deletePrompt
+      tags:
+        - Prompts
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The unique UUID of the prompt.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - "Forbidden: Attempting to delete a prompt with viewer permissions."
+        - "NotFound: Attempting to delete a non-existent prompt ID or a prompt under an unauthorized team."
+      x-test-coverage:
+        - "TestDeletePrompt_Success: Verifies deleting with editor token."
+        - "TestDeletePrompt_ViewerForbidden: Verifies viewer gets a 403 response."
+        - "TestDeletePrompt_NotFound: Verifies 404 response on missing prompt ID."
+      responses:
+        "204":
+          description: Prompt deleted successfully
+        "400":
+          description: Invalid input or invalid UUID format
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "403":
+          description: Forbidden - Viewer or unauthorized team member
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Prompt not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
 
   /v1/prompts/{id}/archive:
     post:

--- a/internal/apierr/errors.go
+++ b/internal/apierr/errors.go
@@ -21,7 +21,11 @@ func (e *APIError) Error() string {
 // Respond sends the API error as a JSON response using the configured structure.
 func (e *APIError) Respond(c *fiber.Ctx, errs ...error) error {
 	if len(errs) > 0 && errs[0] != nil {
-		log.Printf("[ERROR] status=%d method=%s path=%s err=%v msg=%s", e.Status, c.Method(), c.Path(), errs[0], e.Message)
+		if e.Status >= 500 {
+			log.Printf("[ERROR] status=%d method=%s path=%s err=%v msg=%s", e.Status, c.Method(), c.Path(), errs[0], e.Message)
+		} else {
+			log.Printf("[WARN] status=%d method=%s path=%s err=%v msg=%s", e.Status, c.Method(), c.Path(), errs[0], e.Message)
+		}
 	} else if e.Status >= 500 {
 		log.Printf("[ERROR] status=%d method=%s path=%s msg=%s", e.Status, c.Method(), c.Path(), e.Message)
 	} else if e.Status >= 400 {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,6 +80,7 @@ func New() *fiber.App {
 	prompts.Get("", handler.ListAllPrompts)
 	prompts.Get("/:id", handler.GetPrompt)
 	prompts.Put("/:id", handler.UpdatePrompt)
+	prompts.Delete("/:id", handler.DeletePrompt)
 	prompts.Post("/:id/archive", handler.ArchivePrompt)
 	prompts.Post("/:id/restore", handler.RestorePrompt)
 	prompts.Post("/:id/move", handler.MovePrompt)

--- a/internal/db/migrations/020_prompts_fts.sql
+++ b/internal/db/migrations/020_prompts_fts.sql
@@ -1,0 +1,28 @@
+-- Add a pre-computed tsvector column for full-text search.
+-- Weights: name=A (highest), description=B, slug=C (lowest).
+ALTER TABLE prompts ADD COLUMN IF NOT EXISTS search_vector tsvector;
+
+-- Back-fill for existing rows.
+UPDATE prompts
+SET search_vector =
+    setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(slug, '')), 'C');
+
+-- GIN index for fast FTS queries.
+CREATE INDEX IF NOT EXISTS idx_prompts_search_vector ON prompts USING GIN (search_vector);
+
+-- Trigger function: keeps search_vector in sync on every INSERT or UPDATE.
+CREATE OR REPLACE FUNCTION prompts_search_vector_update() RETURNS trigger AS $$
+BEGIN
+    NEW.search_vector :=
+        setweight(to_tsvector('english', coalesce(NEW.name, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(NEW.description, '')), 'B') ||
+        setweight(to_tsvector('english', coalesce(NEW.slug, '')), 'C');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER trg_prompts_search_vector
+BEFORE INSERT OR UPDATE ON prompts
+FOR EACH ROW EXECUTE FUNCTION prompts_search_vector_update();

--- a/internal/db/migrations/021_prompts_partial_unique.sql
+++ b/internal/db/migrations/021_prompts_partial_unique.sql
@@ -1,0 +1,7 @@
+-- Drop the existing global unique constraints on team_id+name and team_id+slug
+ALTER TABLE prompts DROP CONSTRAINT IF EXISTS uq_prompts_team_name;
+ALTER TABLE prompts DROP CONSTRAINT IF EXISTS uq_prompts_team_slug;
+
+-- Create partial unique indexes that only apply when status is not 'archived'
+CREATE UNIQUE INDEX uq_prompts_team_name_active ON prompts (team_id, name) WHERE status != 'archived';
+CREATE UNIQUE INDEX uq_prompts_team_slug_active ON prompts (team_id, slug) WHERE status != 'archived';

--- a/internal/embedderfactory/factory.go
+++ b/internal/embedderfactory/factory.go
@@ -1,0 +1,53 @@
+// Package embedderfactory constructs the active search.Embedder from environment
+// configuration. It lives in its own package to avoid import cycles.
+package embedderfactory
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+
+	"github.com/px0-ai/px0/internal/search"
+)
+
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]func() search.Embedder)
+)
+
+// Register registers a new embedder provider constructor.
+// This should be called from an init() function in the provider package.
+func Register(name string, constructor func() search.Embedder) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if constructor == nil {
+		panic("embedderfactory: Register constructor is nil")
+	}
+	if _, dup := registry[name]; dup {
+		panic("embedderfactory: Register called twice for provider " + name)
+	}
+	registry[name] = constructor
+}
+
+// NewEmbedder reads the EMBEDDER_PROVIDER environment variable and returns
+// the appropriate search.Embedder implementation.
+func NewEmbedder() (search.Embedder, error) {
+	name := os.Getenv("EMBEDDER_PROVIDER")
+
+	if name == "" || name == "noop" {
+		log.Println("warn: EMBEDDER_PROVIDER not set, embeddings are disabled")
+		return nil, nil // Return nil gracefully, no error.
+	}
+
+	registryMu.RLock()
+	constructor, ok := registry[name]
+	registryMu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("unknown embedder provider %q (did you forget to import it?)", name)
+	}
+
+	log.Printf("info: using %s embedding provider", name)
+	return constructor(), nil
+}

--- a/internal/handler/helpers_test.go
+++ b/internal/handler/helpers_test.go
@@ -46,7 +46,7 @@ func newTestApp(t *testing.T) *testApp {
 	t.Helper()
 	t.Setenv("RESEND_API_KEY", "")
 	testutil.SetupDB(t)
-	search.Init(search.NoopProvider{})
+	search.Init(search.NoopProvider{}, search.NoopProvider{})
 	return &testApp{
 		App: app.New(),
 		t:   t,

--- a/internal/handler/helpers_test.go
+++ b/internal/handler/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/px0-ai/px0/internal/app"
+	"github.com/px0-ai/px0/internal/search"
 	"github.com/px0-ai/px0/internal/store"
 	"github.com/px0-ai/px0/internal/testutil"
 )
@@ -45,6 +46,7 @@ func newTestApp(t *testing.T) *testApp {
 	t.Helper()
 	t.Setenv("RESEND_API_KEY", "")
 	testutil.SetupDB(t)
+	search.Init(search.NoopProvider{})
 	return &testApp{
 		App: app.New(),
 		t:   t,

--- a/internal/handler/prompt.go
+++ b/internal/handler/prompt.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/px0-ai/px0/internal/apierr"
 	"github.com/px0-ai/px0/internal/middleware"
 	"github.com/px0-ai/px0/internal/model"
+	"github.com/px0-ai/px0/internal/search"
 	"github.com/px0-ai/px0/internal/store"
 )
 
@@ -92,6 +94,9 @@ func CreatePrompt(c *fiber.Ctx) error {
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
+
+	syncPromptSearchIndex(c.Context(), prompt)
+
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"prompt": prompt})
 }
 
@@ -117,17 +122,36 @@ func ListPrompts(c *fiber.Ctx) error {
 		return apierr.ErrForbidden.Respond(c)
 	}
 
-	var status *string
-	statusStr := c.Query("status")
-	if statusStr != "" {
-		status = &statusStr
-	}
+	status, archived := parsePromptStatusFilter(c)
 
-	var archived *bool
-	archivedStr := c.Query("archived")
-	if archivedStr != "" {
-		if val, err := strconv.ParseBool(archivedStr); err == nil {
-			archived = &val
+	// Full-text search path: when ?q= is provided, route through the search provider.
+	// Falls back to store.ListPrompts when q is empty (preserves existing behaviour)
+	// or when the provider is a NoopProvider (returns search.ErrNotImplemented).
+	if q := c.Query("q"); q != "" {
+		results, err := search.Get().Search(c.Context(), search.SearchQuery{
+			Q:       q,
+			TeamIDs: []uuid.UUID{teamID},
+			Status:  status,
+		})
+		if err != nil {
+			if errors.Is(err, search.ErrNotImplemented) {
+				// Provider is a NoopProvider; fall through to the store layer below.
+			} else {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+		} else {
+			if len(results) == 0 {
+				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
+			}
+			ids := make([]uuid.UUID, len(results))
+			for i, r := range results {
+				ids[i] = r.PromptID
+			}
+			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
+			if err != nil {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+			return c.JSON(fiber.Map{"prompts": prompts})
 		}
 	}
 
@@ -135,6 +159,7 @@ func ListPrompts(c *fiber.Ctx) error {
 		TeamIDs:  []uuid.UUID{teamID},
 		Archived: archived,
 		Status:   status,
+		Q:        c.Query("q"),
 	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
@@ -230,6 +255,8 @@ func ArchivePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
+	_ = search.Get().Deindex(c.Context(), id)
+
 	prompt, err := store.GetPromptByID(c.Context(), id, teamIDs)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
@@ -269,17 +296,34 @@ func ListAllPrompts(c *fiber.Ctx) error {
 		return apierr.ErrForbidden.Respond(c)
 	}
 
-	var status *string
-	statusStr := c.Query("status")
-	if statusStr != "" {
-		status = &statusStr
-	}
+	status, archived := parsePromptStatusFilter(c)
 
-	var archived *bool
-	archivedStr := c.Query("archived")
-	if archivedStr != "" {
-		if val, err := strconv.ParseBool(archivedStr); err == nil {
-			archived = &val
+	// Full-text search path: when ?q= is provided, route through the search provider.
+	if q := c.Query("q"); q != "" {
+		results, err := search.Get().Search(c.Context(), search.SearchQuery{
+			Q:       q,
+			TeamIDs: []uuid.UUID{teamID},
+			Status:  status,
+		})
+		if err != nil {
+			if errors.Is(err, search.ErrNotImplemented) {
+				// Provider is a NoopProvider; fall through to the store layer below.
+			} else {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+		} else {
+			if len(results) == 0 {
+				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
+			}
+			ids := make([]uuid.UUID, len(results))
+			for i, r := range results {
+				ids[i] = r.PromptID
+			}
+			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
+			if err != nil {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+			return c.JSON(fiber.Map{"prompts": prompts})
 		}
 	}
 
@@ -287,6 +331,7 @@ func ListAllPrompts(c *fiber.Ctx) error {
 		TeamIDs:  []uuid.UUID{teamID},
 		Archived: archived,
 		Status:   status,
+		Q:        c.Query("q"),
 	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
@@ -339,6 +384,8 @@ func UpdatePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
+	syncPromptSearchIndex(c.Context(), prompt)
+
 	return c.JSON(fiber.Map{"prompt": prompt})
 }
 
@@ -376,6 +423,9 @@ func RestorePrompt(c *fiber.Ctx) error {
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
+
+	syncPromptSearchIndex(c.Context(), prompt)
+
 	return c.JSON(fiber.Map{"prompt": prompt})
 }
 
@@ -488,6 +538,9 @@ func MovePrompt(c *fiber.Ctx) error {
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
+
+	syncPromptSearchIndex(c.Context(), prompt)
+
 	return c.JSON(fiber.Map{"prompt": prompt})
 }
 
@@ -561,4 +614,61 @@ func DiffVersions(c *fiber.Ctx) error {
 		"to_template":   toVersion.Template,
 		"diff":          diffText,
 	})
+}
+
+// syncPromptSearchIndex is a helper to push the latest prompt state and tags to the search provider.
+// It is called in a fire-and-forget manner during prompt mutations.
+func syncPromptSearchIndex(ctx context.Context, prompt *model.Prompt) {
+	tagMap, _ := store.GetTagsForPrompt(ctx, prompt.ID)
+	uniqueTags := make(map[string]bool)
+	for _, tags := range tagMap {
+		for _, tag := range tags {
+			uniqueTags[tag] = true
+		}
+	}
+	var tagList []string
+	for tag := range uniqueTags {
+		tagList = append(tagList, tag)
+	}
+
+	_ = search.Get().Index(ctx, search.IndexablePrompt{
+		ID:          prompt.ID,
+		TeamID:      prompt.TeamID,
+		Name:        prompt.Name,
+		Description: prompt.Description,
+		Slug:        prompt.Slug,
+		Status:      prompt.Status,
+		Tags:        tagList,
+	})
+}
+
+// parsePromptStatusFilter normalizes status and archived query parameters into 
+// a robust Status pointer (which universally propagates to FTS and DB fallbacks)
+// and an Archived boolean (for store.ListPrompts backwards-compatibility).
+func parsePromptStatusFilter(c *fiber.Ctx) (*string, *bool) {
+	var status *string
+	statusStr := c.Query("status")
+	if statusStr != "" {
+		status = &statusStr
+	}
+
+	var archived *bool
+	archivedStr := c.Query("archived")
+	if archivedStr != "" {
+		if val, err := strconv.ParseBool(archivedStr); err == nil {
+			archived = &val
+		}
+	}
+
+	// If status is explicitly provided, it always wins (FTS and store both prioritize it).
+	// If no status is provided, we must derive it from archived, or default to "active".
+	if statusStr == "" {
+		val := "active"
+		if archived != nil && *archived {
+			val = "archived"
+		}
+		status = &val
+	}
+
+	return status, archived
 }

--- a/internal/handler/prompt.go
+++ b/internal/handler/prompt.go
@@ -25,6 +25,25 @@ type createPromptRequest struct {
 	Slug        string `json:"slug"`
 }
 
+// parseVectorParam parses a comma-separated float32 slice from a query string value.
+// Returns nil if the string is empty, or an error if any token is not a valid float.
+func parseVectorParam(raw string) ([]float32, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	vec := make([]float32, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		f, err := strconv.ParseFloat(p, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vector value %q: %w", p, err)
+		}
+		vec = append(vec, float32(f))
+	}
+	return vec, nil
+}
+
 func NormalizeSlug(s string) string {
 	s = strings.ToLower(s)
 	var sb strings.Builder
@@ -124,10 +143,50 @@ func ListPrompts(c *fiber.Ctx) error {
 
 	status, archived := parsePromptStatusFilter(c)
 
-	// Full-text search path: when ?q= is provided, route through the search provider.
-	// Falls back to store.ListPrompts when q is empty (preserves existing behaviour)
-	// or when the provider is a NoopProvider (returns search.ErrNotImplemented).
-	if q := c.Query("q"); q != "" {
+	// Full-text search and vector search path.
+	// Vector takes precedence if provided.
+	vectorRaw := c.Query("vector")
+	vector, err := parseVectorParam(vectorRaw)
+	if err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid vector parameter: "+err.Error()).Respond(c)
+	}
+
+	topK := 10
+	if k := c.QueryInt("top_k", 10); k > 0 {
+		topK = k
+	}
+
+	if vector != nil {
+		results, err := search.Get().Search(c.Context(), search.SearchQuery{
+			Vector:  vector,
+			TopK:    topK,
+			TeamIDs: []uuid.UUID{teamID},
+			Status:  status,
+		})
+		if err != nil {
+			if errors.Is(err, search.ErrVectorSearchNotSupported) {
+				return apierr.NewAPIError(fiber.StatusBadRequest, "vector search not supported by the active search provider").Respond(c)
+			}
+			if errors.Is(err, search.ErrNotImplemented) {
+				// Provider is a NoopProvider; fall through to the store layer below.
+			} else {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+		} else {
+			if len(results) == 0 {
+				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
+			}
+			ids := make([]uuid.UUID, len(results))
+			for i, r := range results {
+				ids[i] = r.PromptID
+			}
+			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
+			if err != nil {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+			return c.JSON(fiber.Map{"prompts": prompts})
+		}
+	} else if q := c.Query("q"); q != "" {
 		results, err := search.Get().Search(c.Context(), search.SearchQuery{
 			Q:       q,
 			TeamIDs: []uuid.UUID{teamID},
@@ -298,8 +357,50 @@ func ListAllPrompts(c *fiber.Ctx) error {
 
 	status, archived := parsePromptStatusFilter(c)
 
-	// Full-text search path: when ?q= is provided, route through the search provider.
-	if q := c.Query("q"); q != "" {
+	// Full-text search and vector search path.
+	// Vector takes precedence if provided.
+	vectorRaw := c.Query("vector")
+	vector, err := parseVectorParam(vectorRaw)
+	if err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid vector parameter: "+err.Error()).Respond(c)
+	}
+
+	topK := 10
+	if k := c.QueryInt("top_k", 10); k > 0 {
+		topK = k
+	}
+
+	if vector != nil {
+		results, err := search.Get().Search(c.Context(), search.SearchQuery{
+			Vector:  vector,
+			TopK:    topK,
+			TeamIDs: []uuid.UUID{teamID},
+			Status:  status,
+		})
+		if err != nil {
+			if errors.Is(err, search.ErrVectorSearchNotSupported) {
+				return apierr.NewAPIError(fiber.StatusBadRequest, "vector search not supported by the active search provider").Respond(c)
+			}
+			if errors.Is(err, search.ErrNotImplemented) {
+				// Provider is a NoopProvider; fall through to the store layer below.
+			} else {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+		} else {
+			if len(results) == 0 {
+				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
+			}
+			ids := make([]uuid.UUID, len(results))
+			for i, r := range results {
+				ids[i] = r.PromptID
+			}
+			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
+			if err != nil {
+				return apierr.ErrInternalError.Respond(c, err)
+			}
+			return c.JSON(fiber.Map{"prompts": prompts})
+		}
+	} else if q := c.Query("q"); q != "" {
 		results, err := search.Get().Search(c.Context(), search.SearchQuery{
 			Q:       q,
 			TeamIDs: []uuid.UUID{teamID},

--- a/internal/handler/prompt.go
+++ b/internal/handler/prompt.go
@@ -189,6 +189,7 @@ func ListPrompts(c *fiber.Ctx) error {
 	} else if q := c.Query("q"); q != "" {
 		results, err := search.Get().Search(c.Context(), search.SearchQuery{
 			Q:       q,
+			TopK:    topK,
 			TeamIDs: []uuid.UUID{teamID},
 			Status:  status,
 		})
@@ -219,6 +220,7 @@ func ListPrompts(c *fiber.Ctx) error {
 		Archived: archived,
 		Status:   status,
 		Q:        c.Query("q"),
+		Limit:    &topK,
 	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
@@ -403,6 +405,7 @@ func ListAllPrompts(c *fiber.Ctx) error {
 	} else if q := c.Query("q"); q != "" {
 		results, err := search.Get().Search(c.Context(), search.SearchQuery{
 			Q:       q,
+			TopK:    topK,
 			TeamIDs: []uuid.UUID{teamID},
 			Status:  status,
 		})
@@ -433,6 +436,7 @@ func ListAllPrompts(c *fiber.Ctx) error {
 		Archived: archived,
 		Status:   status,
 		Q:        c.Query("q"),
+		Limit:    &topK,
 	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)

--- a/internal/handler/prompt.go
+++ b/internal/handler/prompt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"unicode"
@@ -141,94 +142,7 @@ func ListPrompts(c *fiber.Ctx) error {
 		return apierr.ErrForbidden.Respond(c)
 	}
 
-	status, archived := parsePromptStatusFilter(c)
-
-	// Full-text search and vector search path.
-	// Vector takes precedence if provided.
-	vectorRaw := c.Query("vector")
-	vector, err := parseVectorParam(vectorRaw)
-	if err != nil {
-		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid vector parameter: "+err.Error()).Respond(c)
-	}
-
-	topK := 10
-	if k := c.QueryInt("top_k", 10); k > 0 {
-		topK = k
-	}
-
-	if vector != nil {
-		results, err := search.Get().Search(c.Context(), search.SearchQuery{
-			Vector:  vector,
-			TopK:    topK,
-			TeamIDs: []uuid.UUID{teamID},
-			Status:  status,
-		})
-		if err != nil {
-			if errors.Is(err, search.ErrVectorSearchNotSupported) {
-				return apierr.NewAPIError(fiber.StatusBadRequest, "vector search not supported by the active search provider").Respond(c)
-			}
-			if errors.Is(err, search.ErrNotImplemented) {
-				// Provider is a NoopProvider; fall through to the store layer below.
-			} else {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-		} else {
-			if len(results) == 0 {
-				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
-			}
-			ids := make([]uuid.UUID, len(results))
-			for i, r := range results {
-				ids[i] = r.PromptID
-			}
-			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
-			if err != nil {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-			return c.JSON(fiber.Map{"prompts": prompts})
-		}
-	} else if q := c.Query("q"); q != "" {
-		results, err := search.Get().Search(c.Context(), search.SearchQuery{
-			Q:       q,
-			TopK:    topK,
-			TeamIDs: []uuid.UUID{teamID},
-			Status:  status,
-		})
-		if err != nil {
-			if errors.Is(err, search.ErrNotImplemented) {
-				// Provider is a NoopProvider; fall through to the store layer below.
-			} else {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-		} else {
-			if len(results) == 0 {
-				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
-			}
-			ids := make([]uuid.UUID, len(results))
-			for i, r := range results {
-				ids[i] = r.PromptID
-			}
-			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
-			if err != nil {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-			return c.JSON(fiber.Map{"prompts": prompts})
-		}
-	}
-
-	prompts, err := store.ListPrompts(c.Context(), store.PromptFilter{
-		TeamIDs:  []uuid.UUID{teamID},
-		Archived: archived,
-		Status:   status,
-		Q:        c.Query("q"),
-		Limit:    &topK,
-	})
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	if prompts == nil {
-		prompts = []*model.Prompt{}
-	}
-	return c.JSON(fiber.Map{"prompts": prompts})
+	return listPromptsForTeam(c, teamID)
 }
 
 func GetPrompt(c *fiber.Ctx) error {
@@ -316,7 +230,7 @@ func ArchivePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	_ = search.Get().Deindex(c.Context(), id)
+	_ = search.GetVector().Deindex(c.Context(), id)
 
 	prompt, err := store.GetPromptByID(c.Context(), id, teamIDs)
 	if err != nil {
@@ -333,7 +247,7 @@ func ListAllPrompts(c *fiber.Ctx) error {
 
 	if teamIDStr == "" {
 		// By default nothing is shown as per backwards-compatible test requirements
-		return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
+		return c.JSON(fiber.Map{"prompts": []*model.Prompt{}, "engine": "fts"})
 	}
 
 	teamID, err := uuid.Parse(teamIDStr)
@@ -357,94 +271,7 @@ func ListAllPrompts(c *fiber.Ctx) error {
 		return apierr.ErrForbidden.Respond(c)
 	}
 
-	status, archived := parsePromptStatusFilter(c)
-
-	// Full-text search and vector search path.
-	// Vector takes precedence if provided.
-	vectorRaw := c.Query("vector")
-	vector, err := parseVectorParam(vectorRaw)
-	if err != nil {
-		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid vector parameter: "+err.Error()).Respond(c)
-	}
-
-	topK := 10
-	if k := c.QueryInt("top_k", 10); k > 0 {
-		topK = k
-	}
-
-	if vector != nil {
-		results, err := search.Get().Search(c.Context(), search.SearchQuery{
-			Vector:  vector,
-			TopK:    topK,
-			TeamIDs: []uuid.UUID{teamID},
-			Status:  status,
-		})
-		if err != nil {
-			if errors.Is(err, search.ErrVectorSearchNotSupported) {
-				return apierr.NewAPIError(fiber.StatusBadRequest, "vector search not supported by the active search provider").Respond(c)
-			}
-			if errors.Is(err, search.ErrNotImplemented) {
-				// Provider is a NoopProvider; fall through to the store layer below.
-			} else {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-		} else {
-			if len(results) == 0 {
-				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
-			}
-			ids := make([]uuid.UUID, len(results))
-			for i, r := range results {
-				ids[i] = r.PromptID
-			}
-			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
-			if err != nil {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-			return c.JSON(fiber.Map{"prompts": prompts})
-		}
-	} else if q := c.Query("q"); q != "" {
-		results, err := search.Get().Search(c.Context(), search.SearchQuery{
-			Q:       q,
-			TopK:    topK,
-			TeamIDs: []uuid.UUID{teamID},
-			Status:  status,
-		})
-		if err != nil {
-			if errors.Is(err, search.ErrNotImplemented) {
-				// Provider is a NoopProvider; fall through to the store layer below.
-			} else {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-		} else {
-			if len(results) == 0 {
-				return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
-			}
-			ids := make([]uuid.UUID, len(results))
-			for i, r := range results {
-				ids[i] = r.PromptID
-			}
-			prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
-			if err != nil {
-				return apierr.ErrInternalError.Respond(c, err)
-			}
-			return c.JSON(fiber.Map{"prompts": prompts})
-		}
-	}
-
-	prompts, err := store.ListPrompts(c.Context(), store.PromptFilter{
-		TeamIDs:  []uuid.UUID{teamID},
-		Archived: archived,
-		Status:   status,
-		Q:        c.Query("q"),
-		Limit:    &topK,
-	})
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	if prompts == nil {
-		prompts = []*model.Prompt{}
-	}
-	return c.JSON(fiber.Map{"prompts": prompts})
+	return listPromptsForTeam(c, teamID)
 }
 
 type updatePromptRequest struct {
@@ -524,7 +351,7 @@ func DeletePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	search.Get().Deindex(c.Context(), id)
+	search.GetVector().Deindex(c.Context(), id)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -771,7 +598,7 @@ func syncPromptSearchIndex(ctx context.Context, prompt *model.Prompt) {
 		tagList = append(tagList, tag)
 	}
 
-	_ = search.Get().Index(ctx, search.IndexablePrompt{
+	if err := search.GetVector().Index(ctx, search.IndexablePrompt{
 		ID:          prompt.ID,
 		TeamID:      prompt.TeamID,
 		Name:        prompt.Name,
@@ -779,10 +606,12 @@ func syncPromptSearchIndex(ctx context.Context, prompt *model.Prompt) {
 		Slug:        prompt.Slug,
 		Status:      prompt.Status,
 		Tags:        tagList,
-	})
+	}); err != nil {
+		log.Printf("warn: search index failed for prompt %s: %v", prompt.ID, err)
+	}
 }
 
-// parsePromptStatusFilter normalizes status and archived query parameters into 
+// parsePromptStatusFilter normalizes status and archived query parameters into
 // a robust Status pointer (which universally propagates to FTS and DB fallbacks)
 // and an Archived boolean (for store.ListPrompts backwards-compatibility).
 func parsePromptStatusFilter(c *fiber.Ctx) (*string, *bool) {
@@ -811,4 +640,219 @@ func parsePromptStatusFilter(c *fiber.Ctx) (*string, *bool) {
 	}
 
 	return status, archived
+}
+
+// listPromptsForTeam is the shared, mode-aware implementation used by
+// ListPrompts (team-scoped) and ListAllPrompts (cross-team). It reads the
+// ?mode= query parameter and dispatches to the appropriate ranking engine.
+//
+// Mode routing:
+//   - "fts" (default): real PostgreSQL FTS via the search provider when ?q=
+//     is set, plain listing otherwise. Does not silently fall back to ILIKE.
+//   - "vector": pre-computed ?vector= or an embedded ?q=. Embedder must be
+//     configured; embedding failures yield 501 — never a silent alias to FTS.
+//   - "hybrid": returns 501 (not yet implemented).
+//
+// For backward compatibility, callers that omit ?mode= but supply a raw
+// ?vector= are routed to mode=vector (the historical behaviour). Callers
+// that supply ?q= without ?mode= are routed to mode=fts.
+//
+// Every successful response includes an "engine" field identifying which
+// path actually served the request, so clients (and tests) can verify the
+// mode they asked for is the mode that ran.
+func listPromptsForTeam(c *fiber.Ctx, teamID uuid.UUID) error {
+	status, archived := parsePromptStatusFilter(c)
+
+	mode, ok := parseSearchMode(c)
+	if !ok {
+		// parseSearchMode already wrote a 4xx response; return nil so
+		// fiber doesn't run ErrorHandler on top of it.
+		return nil
+	}
+
+	// Backward-compat: callers predating ?mode= may still send ?vector=
+	// without ?mode=; treat that as an implicit mode=vector request.
+	if mode == "fts" && strings.TrimSpace(c.Query("vector")) != "" {
+		mode = "vector"
+	}
+
+	topK := 10
+	if k := c.QueryInt("top_k", 10); k > 0 {
+		topK = k
+	}
+
+	switch mode {
+	case "fts":
+		return runFTSMode(c, teamID, status, archived, topK)
+	case "vector":
+		return runVectorMode(c, teamID, status, topK)
+	case "hybrid":
+		return apierr.NewAPIError(fiber.StatusNotImplemented, "hybrid search not implemented").Respond(c)
+	}
+	return apierr.ErrInternalError.Respond(c, fmt.Errorf("unhandled search mode %q", mode))
+}
+
+// parseSearchMode reads ?mode= and validates it. An empty or missing
+// value defaults to "fts". On invalid input, it writes a 400 response
+// and returns ok=false so the caller can short-circuit with a nil
+// return — returning a non-nil error here would cause fiber's
+// ErrorHandler to attempt another write and potentially clobber the
+// 400 with a 500.
+func parseSearchMode(c *fiber.Ctx) (string, bool) {
+	raw := strings.ToLower(strings.TrimSpace(c.Query("mode")))
+	switch raw {
+	case "":
+		return "fts", true
+	case "fts", "vector", "hybrid":
+		return raw, true
+	default:
+		_ = apierr.NewAPIError(fiber.StatusBadRequest, "invalid mode: must be one of 'fts', 'vector', 'hybrid'").Respond(c)
+		return "", false
+	}
+}
+
+// runFTSMode handles mode=fts. With ?q= set, it routes to the FTS
+// search provider (PostgreSQL FTS when that provider is active) via
+// search.GetFTS().Search. Without ?q=, it returns a plain listing.
+//
+// Unlike the previous behaviour, this path never silently falls back to
+// the ILIKE-based store.ListPrompts. A search provider that returns
+// ErrNotImplemented or ErrVectorSearchNotSupported produces 501.
+func runFTSMode(c *fiber.Ctx, teamID uuid.UUID, status *string, archived *bool, topK int) error {
+	q := c.Query("q")
+	if q == "" {
+		return runPlainList(c, teamID, status, archived, topK)
+	}
+
+	results, err := search.GetFTS().Search(c.Context(), search.SearchQuery{
+		Q:       q,
+		TopK:    topK,
+		TeamIDs: []uuid.UUID{teamID},
+		Status:  status,
+	})
+	if err != nil {
+		if errors.Is(err, search.ErrNotImplemented) {
+			return apierr.NewAPIError(fiber.StatusNotImplemented, "fts search not implemented by the active search provider").Respond(c)
+		}
+		if errors.Is(err, search.ErrVectorSearchNotSupported) {
+			// An active embedder auto-converted the FTS query into a vector
+			// query and the underlying provider does not support vectors.
+			// Surface the mismatch rather than aliasing to anything else.
+			return apierr.NewAPIError(fiber.StatusNotImplemented, "fts search not available: the active search provider does not support FTS for this query").Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return respondWithPromptIDs(c, results, teamID, status, "fts")
+}
+
+// runPlainList returns a non-search listing of prompts for the team,
+// filtered by status/archived. Used by mode=fts when ?q= is empty.
+func runPlainList(c *fiber.Ctx, teamID uuid.UUID, status *string, archived *bool, topK int) error {
+	prompts, err := store.ListPromptsByFilter(c.Context(), store.PromptFilter{
+		TeamIDs:  []uuid.UUID{teamID},
+		Archived: archived,
+		Status:   status,
+		Limit:    &topK,
+	})
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if prompts == nil {
+		prompts = []*model.Prompt{}
+	}
+	return c.JSON(fiber.Map{"prompts": prompts, "engine": "fts"})
+}
+
+// runVectorMode handles mode=vector. It resolves a query vector from
+// ?vector= or, when only ?q= is provided, by asking the global embedder
+// to embed the text. A missing or failing embedder yields 501 — no
+// silent alias to FTS or to plain listing.
+func runVectorMode(c *fiber.Ctx, teamID uuid.UUID, status *string, topK int) error {
+	vector, ok := resolveVectorFromQuery(c)
+	if !ok {
+		// resolveVectorFromQuery already wrote a 4xx/5xx response;
+		// return nil so fiber doesn't run ErrorHandler on top of it.
+		return nil
+	}
+	if vector == nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "vector mode requires either vector= or q= parameter").Respond(c)
+	}
+
+	results, err := search.GetVector().Search(c.Context(), search.SearchQuery{
+		Vector:  vector,
+		TopK:    topK,
+		TeamIDs: []uuid.UUID{teamID},
+		Status:  status,
+	})
+	if err != nil {
+		if errors.Is(err, search.ErrVectorSearchNotSupported) {
+			return apierr.NewAPIError(fiber.StatusBadRequest, "vector search not supported by the active search provider").Respond(c)
+		}
+		if errors.Is(err, search.ErrNotImplemented) {
+			return apierr.NewAPIError(fiber.StatusNotImplemented, "vector search not implemented by the active search provider").Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return respondWithPromptIDs(c, results, teamID, status, "vector")
+}
+
+// resolveVectorFromQuery returns a query vector using, in order:
+//  1. a pre-computed ?vector= parameter (no embedder required),
+//  2. an embedded ?q= via the global embedder (require a working embedder),
+//  3. (nil, true) when neither is supplied, so the caller can produce a
+//     precise 400 explaining that vector mode needs a vector.
+//
+// On embedder absence or embed failure, it writes a 4xx/5xx response
+// via apierr.Respond and returns ok=false so the caller can short-circuit
+// with a nil return. Same rationale as parseSearchMode: returning a
+// non-nil error from the handler would invoke fiber's ErrorHandler
+// and potentially clobber the response already written by Respond.
+func resolveVectorFromQuery(c *fiber.Ctx) ([]float32, bool) {
+	vectorRaw := c.Query("vector")
+	vector, err := parseVectorParam(vectorRaw)
+	if err != nil {
+		_ = apierr.NewAPIError(fiber.StatusBadRequest, "invalid vector parameter: "+err.Error()).Respond(c)
+		return nil, false
+	}
+	if vector != nil {
+		return vector, true
+	}
+
+	q := c.Query("q")
+	if q == "" {
+		return nil, true
+	}
+
+	embedder := search.GetEmbedder()
+	if embedder == nil {
+		_ = apierr.NewAPIError(fiber.StatusNotImplemented, "vector search unavailable: no embedder configured (set EMBEDDER_PROVIDER and HF_TOKEN)").Respond(c)
+		return nil, false
+	}
+
+	embedded, err := embedder.Embed(c.Context(), q)
+	if err != nil {
+		_ = apierr.NewAPIError(fiber.StatusNotImplemented, "vector search unavailable: embedding failed: "+err.Error()).Respond(c)
+		return nil, false
+	}
+	return embedded, true
+}
+
+// respondWithPromptIDs hydrates the given SearchResults into full Prompt
+// records (preserving the provider's score order) and writes the standard
+// {"prompts": [...], "engine": <engine>} JSON response. The "engine" field
+// always reflects the path that produced the results, never the caller's
+// requested mode, so clients can detect mismatches.
+func respondWithPromptIDs(c *fiber.Ctx, results []search.SearchResult, teamID uuid.UUID, status *string, engine string) error {
+	if len(results) == 0 {
+		return c.JSON(fiber.Map{"prompts": []*model.Prompt{}, "engine": engine})
+	}
+	ids := make([]uuid.UUID, len(results))
+	for i, r := range results {
+		ids[i] = r.PromptID
+	}
+	prompts, err := store.GetPromptsByIDs(c.Context(), ids, []uuid.UUID{teamID}, status)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return c.JSON(fiber.Map{"prompts": prompts, "engine": engine})
 }

--- a/internal/handler/prompt.go
+++ b/internal/handler/prompt.go
@@ -389,6 +389,41 @@ func UpdatePrompt(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"prompt": prompt})
 }
 
+func DeletePrompt(c *fiber.Ctx) error {
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return apierr.ErrInvalidPromptID.Respond(c)
+	}
+
+	teamIDs, err := getRequestTeamIDs(c)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	if _, err := store.GetPromptByID(c.Context(), id, teamIDs); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrPromptNotFound.Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	if err := store.DeletePrompt(c.Context(), id, editorTeamIDs); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrForbidden.Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	search.Get().Deindex(c.Context(), id)
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
 func RestorePrompt(c *fiber.Ctx) error {
 	id, err := uuid.Parse(c.Params("id"))
 	if err != nil {

--- a/internal/handler/prompt_mutation_test.go
+++ b/internal/handler/prompt_mutation_test.go
@@ -1,0 +1,113 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/px0-ai/px0/internal/model"
+	"github.com/px0-ai/px0/internal/search"
+)
+
+type mockProvider struct {
+	IndexCalls   []search.IndexablePrompt
+	DeindexCalls []uuid.UUID
+}
+
+func (m *mockProvider) Search(ctx context.Context, q search.SearchQuery) ([]search.SearchResult, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) Index(ctx context.Context, p search.IndexablePrompt) error {
+	m.IndexCalls = append(m.IndexCalls, p)
+	return nil
+}
+
+func (m *mockProvider) Deindex(ctx context.Context, promptID uuid.UUID) error {
+	m.DeindexCalls = append(m.DeindexCalls, promptID)
+	return nil
+}
+
+func TestPromptMutations_SearchTriggers(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	// Inject the mock provider and restore it after
+	originalProvider := search.Get()
+	mock := &mockProvider{}
+	search.Init(mock)
+	t.Cleanup(func() { search.Init(originalProvider) })
+
+	// 1. Create a prompt (should trigger Index)
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+		`{"name":"Trigger Test","description":"Initial desc","slug":"trigger_test"}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	
+	body := decodeBody(t, resp)
+	promptMap := body["prompt"].(map[string]any)
+	promptIDStr := promptMap["id"].(string)
+	promptID := uuid.MustParse(promptIDStr)
+
+	require.Len(t, mock.IndexCalls, 1, "CreatePrompt should call Index once")
+	assert.Equal(t, promptID, mock.IndexCalls[0].ID)
+	assert.Equal(t, "Trigger Test", mock.IndexCalls[0].Name)
+	assert.Equal(t, "Initial desc", mock.IndexCalls[0].Description)
+	assert.Equal(t, "trigger_test", mock.IndexCalls[0].Slug)
+	assert.Equal(t, model.PromptStatusActive, mock.IndexCalls[0].Status)
+	assert.Empty(t, mock.IndexCalls[0].Tags) // No tags initially
+
+	// Clear mock calls for the next step
+	mock.IndexCalls = nil
+
+	// 2. Update the prompt (should trigger Index)
+	req = newReq(t, http.MethodPut, fmt.Sprintf("/v1/prompts/%s", promptID),
+		`{"description":"Updated desc"}`, token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Len(t, mock.IndexCalls, 1, "UpdatePrompt should call Index once")
+	assert.Equal(t, promptID, mock.IndexCalls[0].ID)
+	assert.Equal(t, "Updated desc", mock.IndexCalls[0].Description)
+
+	// Clear mock calls
+	mock.IndexCalls = nil
+
+	// 3. Create a version and tag it (should trigger Index to update tags)
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions", promptID),
+		`{"template":"Hello world"}`, token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions/1/tags", promptID),
+		`{"tag":"live"}`, token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Len(t, mock.IndexCalls, 1, "SetTag should call Index once")
+	assert.Equal(t, promptID, mock.IndexCalls[0].ID)
+	assert.Contains(t, mock.IndexCalls[0].Tags, "live")
+
+	// Clear mock calls
+	mock.IndexCalls = nil
+
+	// 4. Archive the prompt (should trigger Deindex)
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", promptID), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Len(t, mock.DeindexCalls, 1, "ArchivePrompt should call Deindex once")
+	assert.Equal(t, promptID, mock.DeindexCalls[0])
+	require.Len(t, mock.IndexCalls, 0, "ArchivePrompt should not call Index")
+}

--- a/internal/handler/prompt_mutation_test.go
+++ b/internal/handler/prompt_mutation_test.go
@@ -14,21 +14,44 @@ import (
 	"github.com/px0-ai/px0/internal/search"
 )
 
-type mockProvider struct {
-	IndexCalls   []search.IndexablePrompt
-	DeindexCalls []uuid.UUID
+type mockFTSProvider struct {
+	SearchCalls   int
+	IndexCalls    []search.IndexablePrompt
+	DeindexCalls  []uuid.UUID
 }
 
-func (m *mockProvider) Search(ctx context.Context, q search.SearchQuery) ([]search.SearchResult, error) {
+func (m *mockFTSProvider) Search(ctx context.Context, q search.SearchQuery) ([]search.SearchResult, error) {
+	m.SearchCalls++
 	return nil, nil
 }
 
-func (m *mockProvider) Index(ctx context.Context, p search.IndexablePrompt) error {
+func (m *mockFTSProvider) Index(ctx context.Context, p search.IndexablePrompt) error {
 	m.IndexCalls = append(m.IndexCalls, p)
 	return nil
 }
 
-func (m *mockProvider) Deindex(ctx context.Context, promptID uuid.UUID) error {
+func (m *mockFTSProvider) Deindex(ctx context.Context, promptID uuid.UUID) error {
+	m.DeindexCalls = append(m.DeindexCalls, promptID)
+	return nil
+}
+
+type mockVectorProvider struct {
+	SearchCalls  int
+	IndexCalls   []search.IndexablePrompt
+	DeindexCalls []uuid.UUID
+}
+
+func (m *mockVectorProvider) Search(ctx context.Context, q search.SearchQuery) ([]search.SearchResult, error) {
+	m.SearchCalls++
+	return nil, nil
+}
+
+func (m *mockVectorProvider) Index(ctx context.Context, p search.IndexablePrompt) error {
+	m.IndexCalls = append(m.IndexCalls, p)
+	return nil
+}
+
+func (m *mockVectorProvider) Deindex(ctx context.Context, promptID uuid.UUID) error {
 	m.DeindexCalls = append(m.DeindexCalls, promptID)
 	return nil
 }
@@ -38,34 +61,42 @@ func TestPromptMutations_SearchTriggers(t *testing.T) {
 	token := setupUser(t, a)
 	teamID := setupUserTeam(t, token)
 
-	// Inject the mock provider and restore it after
-	originalProvider := search.Get()
-	mock := &mockProvider{}
-	search.Init(mock)
-	t.Cleanup(func() { search.Init(originalProvider) })
+	// Inject mock providers and restore the originals after.
+	originalFTS := search.GetFTS()
+	originalVector := search.GetVector()
+	mockFTS := &mockFTSProvider{}
+	mockVector := &mockVectorProvider{}
+	search.Init(mockFTS, mockVector)
+	t.Cleanup(func() { search.Init(originalFTS, originalVector) })
 
-	// 1. Create a prompt (should trigger Index)
+	// 1. Create a prompt (should trigger Index on the vector provider,
+	// since that's the one wrapped in the embedding decorator).
 	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
 		`{"name":"Trigger Test","description":"Initial desc","slug":"trigger_test"}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-	
+
 	body := decodeBody(t, resp)
 	promptMap := body["prompt"].(map[string]any)
 	promptIDStr := promptMap["id"].(string)
 	promptID := uuid.MustParse(promptIDStr)
 
-	require.Len(t, mock.IndexCalls, 1, "CreatePrompt should call Index once")
-	assert.Equal(t, promptID, mock.IndexCalls[0].ID)
-	assert.Equal(t, "Trigger Test", mock.IndexCalls[0].Name)
-	assert.Equal(t, "Initial desc", mock.IndexCalls[0].Description)
-	assert.Equal(t, "trigger_test", mock.IndexCalls[0].Slug)
-	assert.Equal(t, model.PromptStatusActive, mock.IndexCalls[0].Status)
-	assert.Empty(t, mock.IndexCalls[0].Tags) // No tags initially
+	require.Len(t, mockVector.IndexCalls, 1, "CreatePrompt should call Index on the vector provider once")
+	assert.Equal(t, promptID, mockVector.IndexCalls[0].ID)
+	assert.Equal(t, "Trigger Test", mockVector.IndexCalls[0].Name)
+	assert.Equal(t, "Initial desc", mockVector.IndexCalls[0].Description)
+	assert.Equal(t, "trigger_test", mockVector.IndexCalls[0].Slug)
+	assert.Equal(t, model.PromptStatusActive, mockVector.IndexCalls[0].Status)
+	assert.Empty(t, mockVector.IndexCalls[0].Tags) // No tags initially
+
+	// FTS Index should NOT be called for plain FTS providers
+	// (postgres is a no-op; qdrant would not receive the index either
+	// since the handler routes Index through the vector slot only).
+	assert.Empty(t, mockFTS.IndexCalls, "FTS provider's Index should not be called")
 
 	// Clear mock calls for the next step
-	mock.IndexCalls = nil
+	mockVector.IndexCalls = nil
 
 	// 2. Update the prompt (should trigger Index)
 	req = newReq(t, http.MethodPut, fmt.Sprintf("/v1/prompts/%s", promptID),
@@ -74,12 +105,12 @@ func TestPromptMutations_SearchTriggers(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	require.Len(t, mock.IndexCalls, 1, "UpdatePrompt should call Index once")
-	assert.Equal(t, promptID, mock.IndexCalls[0].ID)
-	assert.Equal(t, "Updated desc", mock.IndexCalls[0].Description)
+	require.Len(t, mockVector.IndexCalls, 1, "UpdatePrompt should call Index once")
+	assert.Equal(t, promptID, mockVector.IndexCalls[0].ID)
+	assert.Equal(t, "Updated desc", mockVector.IndexCalls[0].Description)
 
 	// Clear mock calls
-	mock.IndexCalls = nil
+	mockVector.IndexCalls = nil
 
 	// 3. Create a version and tag it (should trigger Index to update tags)
 	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions", promptID),
@@ -94,20 +125,20 @@ func TestPromptMutations_SearchTriggers(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	require.Len(t, mock.IndexCalls, 1, "SetTag should call Index once")
-	assert.Equal(t, promptID, mock.IndexCalls[0].ID)
-	assert.Contains(t, mock.IndexCalls[0].Tags, "live")
+	require.Len(t, mockVector.IndexCalls, 1, "SetTag should call Index once")
+	assert.Equal(t, promptID, mockVector.IndexCalls[0].ID)
+	assert.Contains(t, mockVector.IndexCalls[0].Tags, "live")
 
 	// Clear mock calls
-	mock.IndexCalls = nil
+	mockVector.IndexCalls = nil
 
-	// 4. Archive the prompt (should trigger Deindex)
+	// 4. Archive the prompt (should trigger Deindex on the vector provider)
 	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", promptID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	require.Len(t, mock.DeindexCalls, 1, "ArchivePrompt should call Deindex once")
-	assert.Equal(t, promptID, mock.DeindexCalls[0])
-	require.Len(t, mock.IndexCalls, 0, "ArchivePrompt should not call Index")
+	require.Len(t, mockVector.DeindexCalls, 1, "ArchivePrompt should call Deindex on the vector provider once")
+	assert.Equal(t, promptID, mockVector.DeindexCalls[0])
+	require.Len(t, mockVector.IndexCalls, 0, "ArchivePrompt should not call Index")
 }

--- a/internal/handler/prompt_test.go
+++ b/internal/handler/prompt_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/px0-ai/px0/internal/search"
+	"github.com/px0-ai/px0/internal/search/hf"
 	"github.com/px0-ai/px0/internal/searchfactory"
 	"github.com/px0-ai/px0/internal/store"
 )
@@ -166,15 +167,16 @@ func TestListPrompts_Filters(t *testing.T) {
 	body := decodeBody(t, resp)
 	techPromptID := body["prompt"].(map[string]any)["id"].(string)
 
-	// 1. Search with Q=billing
+	// 1. Search with Q=billing. The default NoopProvider does not implement
+	// FTS, so this must surface as 501 — the previous behaviour of
+	// silently falling back to ILIKE is no longer reachable.
 	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?q=billing", teamID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
 	body = decodeBody(t, resp)
-	prompts := body["prompts"].([]any)
-	assert.Len(t, prompts, 1)
-	assert.Equal(t, "Support Bot", prompts[0].(map[string]any)["name"])
+	assert.Contains(t, body["error"], "fts search not implemented")
+	resp.Body.Close()
 
 	// 2. Archive tech prompt
 	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", techPromptID), "", token)
@@ -183,17 +185,18 @@ func TestListPrompts_Filters(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
 
-	// 3. Default search (should only return active: Support Bot)
+	// 3. Default search (no q, no vector) — plain listing, only active: Support Bot
 	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teamID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body = decodeBody(t, resp)
-	prompts = body["prompts"].([]any)
+	prompts := body["prompts"].([]any)
 	assert.Len(t, prompts, 1)
 	assert.Equal(t, "Support Bot", prompts[0].(map[string]any)["name"])
+	assert.Equal(t, "fts", body["engine"])
 
-	// 4. Search with archived=true
+	// 4. Listing with archived=true — plain listing, only archived: Tech Bot
 	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?archived=true", teamID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
@@ -757,22 +760,26 @@ func TestDiffVersions(t *testing.T) {
 }
 
 func TestSearchPrompts_FTS(t *testing.T) {
-	// Enable postgres search provider for this test
-	t.Setenv("SEARCH_PROVIDER", "postgres")
+	// Enable postgres FTS provider for this test
+	t.Setenv("SEARCH_FTS_PROVIDER", "postgres")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "noop")
 
 	a := newTestApp(t)
 	token := setupUser(t, a)
 	teamID := setupUserTeam(t, token)
 
-	// Build the real Postgres provider and wire it to search.Default
+	// Build the real Postgres FTS provider and a noop vector provider
+	// and wire both to search.
 	ctx := context.Background()
-	p, err := searchfactory.NewProvider(ctx)
+	fts, err := searchfactory.NewFTSProvider(ctx)
 	require.NoError(t, err)
-	search.Init(p)
+	vec, err := searchfactory.NewVectorProvider(ctx)
+	require.NoError(t, err)
+	search.Init(fts, vec)
 
 	// Clean up global state after test
 	t.Cleanup(func() {
-		search.Init(search.NoopProvider{})
+		search.Init(search.NoopProvider{}, search.NoopProvider{})
 	})
 
 	// Create 3 prompts with differing names/descriptions/status
@@ -874,7 +881,9 @@ func TestListPrompts_InvalidVector(t *testing.T) {
 }
 
 func TestListPrompts_VectorUnsupportedProvider(t *testing.T) {
-	// Active provider is NoopProvider by default in tests
+	// Active provider is NoopProvider by default in tests. A vector
+	// request must surface the unavailability as 501, not silently
+	// fall back to the FTS / listing path.
 	a := newTestApp(t)
 	token := setupUser(t, a)
 	teamID := setupUserTeam(t, token)
@@ -884,11 +893,191 @@ func TestListPrompts_VectorUnsupportedProvider(t *testing.T) {
 	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?vector=0.1,0.2,0.3", teamID), "", token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
-	// Should fall back to store.ListPrompts and return OK
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
 	body := decodeBody(t, resp)
-	prompts := body["prompts"].([]any)
-	assert.Len(t, prompts, 1)
+	assert.Contains(t, body["error"], "vector search not implemented")
+}
+
+func TestListPrompts_EngineFieldDefault(t *testing.T) {
+	// No ?q= and no ?vector= → plain listing with engine=fts.
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	setupPrompt(t, a, token)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Equal(t, "fts", body["engine"], "default mode must report engine=fts")
+}
+
+func TestListPrompts_InvalidMode(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?mode=bogus", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Contains(t, body["error"], "invalid mode")
+}
+
+func TestListPrompts_ModeHybridReturns501(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?mode=hybrid&q=hello", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Contains(t, body["error"], "hybrid search not implemented")
+}
+
+func TestListPrompts_ModeVectorNoQueryNoVector(t *testing.T) {
+	// mode=vector with neither vector= nor q= must 400 with a clear error,
+	// not silently fall through to FTS.
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?mode=vector", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Contains(t, body["error"], "vector mode requires")
+}
+
+func TestListPrompts_ModeVectorNoEmbedder(t *testing.T) {
+	// mode=vector with a q but no embedder registered must 501,
+	// not silently fall through to FTS or listing.
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?mode=vector&q=hello", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Contains(t, body["error"], "vector search unavailable")
+	assert.Contains(t, body["error"], "no embedder configured")
+}
+
+func TestListAllPrompts_EngineField(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	req := newReq(t, http.MethodGet, "/v1/prompts", "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Equal(t, "fts", body["engine"], "no-team list should also report engine=fts")
+	assert.Empty(t, body["prompts"])
+
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?team_id=%s", teamID), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body = decodeBody(t, resp)
+	assert.Equal(t, "fts", body["engine"])
+}
+
+// TestListPrompts_FTSMode_DoesNotAutoEmbed is the regression test for
+// the Phase 2 fix. Before the fix, mode=fts with an embedder registered
+// would silently auto-embed the text query and pass it as a vector to
+// the FTS provider, which would then return 501 (vector not supported).
+// After the fix, mode=fts must NOT touch the embedder at all — the FTS
+// provider receives a plain text SearchQuery with Vector unset.
+//
+// We assert this by:
+//  1. Setting a noop vector provider (so any vector path would 501).
+//  2. Registering a real (HF) embedder.
+//  3. Sending mode=fts&q=hello and asserting we get a 200 from the FTS
+//     path, not a 501 from the vector path. With the auto-embed bug
+//     the query would reach the FTS provider as a vector and 501.
+func TestListPrompts_FTSMode_DoesNotAutoEmbed(t *testing.T) {
+	t.Setenv("EMBEDDER_PROVIDER", "huggingface")
+	t.Setenv("HF_TOKEN", "fake-token-for-test") // any non-empty value
+	t.Setenv("SEARCH_FTS_PROVIDER", "postgres")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "noop")
+
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	// Wire the real FTS provider and a noop vector provider.
+	ctx := context.Background()
+	fts, err := searchfactory.NewFTSProvider(ctx)
+	require.NoError(t, err)
+	vec, err := searchfactory.NewVectorProvider(ctx)
+	require.NoError(t, err)
+	search.Init(fts, vec)
+
+	// Register an HF embedder (the auto-embed bug's trigger).
+	search.SetEmbedder(hf.NewEmbedder())
+	t.Cleanup(func() {
+		search.SetEmbedder(nil)
+		search.Init(search.NoopProvider{}, search.NoopProvider{})
+	})
+
+	// Create a prompt so the FTS query has something to find.
+	createReq := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+		`{"name":"FTS Mode No Auto Embed","description":"hello world"}`, token)
+	createResp, err := a.Test(createReq)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, createResp.StatusCode)
+	createResp.Body.Close()
+
+	// mode=fts with a text query. With the auto-embed bug, this would
+	// silently embed the query and pass it as a vector to the FTS
+	// provider, which would 501. After the fix, the FTS provider
+	// receives a plain text query and does FTS.
+	req := newReq(t, http.MethodGet,
+		fmt.Sprintf("/v1/teams/%s/prompts?mode=fts&q=hello", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+
+	// The response should be a real FTS result (200) or an empty FTS
+	// result (200), NOT a 501 from the FTS provider receiving a vector.
+	// An empty result is possible because the tsvector may not match
+	// the user's plain text in a way that exceeds the rank threshold.
+	assert.NotEqual(t, http.StatusNotImplemented, resp.StatusCode,
+		"mode=fts must not auto-embed; got 501 (auto-embed bug still present)")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Equal(t, "fts", body["engine"])
+}
+
+// TestListPrompts_VectorMode_StillRequiresEmbedder confirms that the
+// Phase 2 fix did not regress mode=vector: with no embedder, mode=vector
+// + q= still 501s (resolveVectorFromQuery is still the sole path that
+// embeds a text query into a vector).
+func TestListPrompts_VectorMode_StillRequiresEmbedder(t *testing.T) {
+	// Make sure no embedder is registered.
+	t.Setenv("EMBEDDER_PROVIDER", "")
+	t.Setenv("HF_TOKEN", "")
+
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	// mode=vector + q but no embedder should 501.
+	req := newReq(t, http.MethodGet,
+		fmt.Sprintf("/v1/teams/%s/prompts?mode=vector&q=hello", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Contains(t, body["error"], "no embedder configured")
 }
 

--- a/internal/handler/prompt_test.go
+++ b/internal/handler/prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/google/uuid"
@@ -1056,6 +1057,132 @@ func TestListPrompts_FTSMode_DoesNotAutoEmbed(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body := decodeBody(t, resp)
 	assert.Equal(t, "fts", body["engine"])
+}
+
+// TestListPrompts_FTS_ORSemantics verifies that the Postgres FTS provider
+// uses OR semantics (any term match) with a minimum ts_rank threshold,
+// replacing the previous AND semantics that made multi-word natural-language
+// queries return zero results when not every token appeared in the document.
+func TestListPrompts_FTS_ORSemantics(t *testing.T) {
+	// Wire the real Postgres FTS provider so search.GetFTS() is not Noop.
+	t.Setenv("SEARCH_FTS_PROVIDER", "postgres")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "noop")
+	t.Setenv("EMBEDDER_PROVIDER", "")
+
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	ctx := context.Background()
+	fts, err := searchfactory.NewFTSProvider(ctx)
+	require.NoError(t, err)
+	vec, err := searchfactory.NewVectorProvider(ctx)
+	require.NoError(t, err)
+	search.Init(fts, vec)
+	t.Cleanup(func() {
+		search.Init(search.NoopProvider{}, search.NoopProvider{})
+	})
+
+	create := func(name, desc string) string {
+		req := newReq(t, http.MethodPost,
+			fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+			fmt.Sprintf(`{"name":%q,"description":%q}`, name, desc), token)
+		resp, err := a.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		body := decodeBody(t, resp)
+		return body["prompt"].(map[string]any)["id"].(string)
+	}
+
+	create("Bug Tracker", "Helps users report software bugs, app crashes, and installation issues.")
+	create("Crash Reporter", "Collects details on app crashes, bugs, and failed installs.")
+	create("Glossary Lookup", "Defines technical terms, APIs, and acronyms used across the platform.")
+	create("Leave Assistant", "Answers questions about sick leave, vacation days, and sick day policy.")
+	create("Billing Support", "Assists customers with billing errors, payment failures, and refund requests.")
+	create("Weather Widget", "Shows current temperature and forecast for the user location.")
+
+	searchAndAssert := func(query string, wantNames ...string) {
+		u := fmt.Sprintf("/v1/teams/%s/prompts?mode=fts&q=%s", teamID, url.QueryEscape(query))
+		req := newReq(t, http.MethodGet, u, "", token)
+		resp, err := a.Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body := decodeBody(t, resp)
+		assert.Equal(t, "fts", body["engine"])
+
+		prompts := body["prompts"].([]any)
+		got := make(map[string]bool)
+		for _, p := range prompts {
+			name := p.(map[string]any)["name"].(string)
+			got[name] = true
+		}
+		for _, want := range wantNames {
+			assert.True(t, got[want], "query %q: expected %q in results", query, want)
+		}
+	}
+
+	searchAndAssert("app keeps crashing", "Bug Tracker", "Crash Reporter")
+	searchAndAssert("define API", "Glossary Lookup")
+	searchAndAssert("vacation days remaining", "Leave Assistant")
+	searchAndAssert("refund for a failed payment", "Billing Support")
+}
+
+// TestListPrompts_FTS_ORSemantics_RegressionGuard verifies that OR
+// semantics do not produce false positives for out-of-domain queries.
+func TestListPrompts_FTS_ORSemantics_RegressionGuard(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "postgres")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "noop")
+	t.Setenv("EMBEDDER_PROVIDER", "")
+
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	ctx := context.Background()
+	fts, err := searchfactory.NewFTSProvider(ctx)
+	require.NoError(t, err)
+	vec, err := searchfactory.NewVectorProvider(ctx)
+	require.NoError(t, err)
+	search.Init(fts, vec)
+	t.Cleanup(func() {
+		search.Init(search.NoopProvider{}, search.NoopProvider{})
+	})
+
+	create := func(name, desc string) {
+		req := newReq(t, http.MethodPost,
+			fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+			fmt.Sprintf(`{"name":%q,"description":%q}`, name, desc), token)
+		resp, err := a.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	create("Bug Tracker", "Helps users report software bugs, app crashes, and installation issues.")
+	create("Leave Assistant", "Answers questions about sick leave, vacation days, and sick day policy.")
+
+	// "quantum physics homework help" must return no results.
+	req := newReq(t, http.MethodGet,
+		fmt.Sprintf("/v1/teams/%s/prompts?mode=fts&q=%s", teamID,
+			url.QueryEscape("quantum physics homework help")), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeBody(t, resp)
+	prompts := body["prompts"].([]any)
+	assert.Empty(t, prompts, "quantum physics homework help should return no results")
+
+	// "crshing" (typo) — FTS dictionary cannot stem "crshing" to "crash".
+	// Expected: no results. Typo-tolerance is out of scope.
+	req = newReq(t, http.MethodGet,
+		fmt.Sprintf("/v1/teams/%s/prompts?mode=fts&q=%s", teamID,
+			url.QueryEscape("crshing")), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body = decodeBody(t, resp)
+	prompts = body["prompts"].([]any)
+	assert.Empty(t, prompts, "crshing (typo) should return no results — typo tolerance out of scope")
 }
 
 // TestListPrompts_VectorMode_StillRequiresEmbedder confirms that the

--- a/internal/handler/prompt_test.go
+++ b/internal/handler/prompt_test.go
@@ -605,6 +605,75 @@ func TestUpdatePrompt_Handler(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestDeletePrompt_Handler(t *testing.T) {
+	a := newTestApp(t)
+	ctx := context.Background()
+
+	// 1. Setup Admin Token & Team
+	adminToken := setupUser(t, a)
+	teamIDStr := setupUserTeam(t, adminToken)
+	teamID := uuid.MustParse(teamIDStr)
+
+	// Get admin session to match expiration
+	adminSession, err := store.GetSessionByToken(ctx, adminToken)
+	require.NoError(t, err)
+
+	// 2. Setup Editor User & Token
+	editorUser, err := store.CreateVerifiedUser(ctx, "promptdeleteeditor@px0.dev", "Password123!")
+	require.NoError(t, err)
+	err = store.AddTeamMember(ctx, teamID, editorUser.ID)
+	require.NoError(t, err)
+	err = store.UpdateTeamMemberRole(ctx, teamID, editorUser.ID, "editor")
+	require.NoError(t, err)
+
+	editorSession, err := store.CreateSession(ctx, editorUser.ID, "sess_p_delete_editor", adminSession.ExpiresAt)
+	require.NoError(t, err)
+	editorToken := editorSession.Token
+
+	// 3. Setup Viewer User & Token
+	viewerUser, err := store.CreateVerifiedUser(ctx, "promptdeleteviewer@px0.dev", "Password123!")
+	require.NoError(t, err)
+	err = store.AddTeamMember(ctx, teamID, viewerUser.ID)
+	require.NoError(t, err)
+	err = store.UpdateTeamMemberRole(ctx, teamID, viewerUser.ID, "viewer")
+	require.NoError(t, err)
+
+	viewerSession, err := store.CreateSession(ctx, viewerUser.ID, "sess_p_delete_viewer", adminSession.ExpiresAt)
+	require.NoError(t, err)
+	viewerToken := viewerSession.Token
+
+	// 4. Create prompt as editor
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamIDStr),
+		`{"name":"Delete Test Prompt","description":"Initial description"}`, editorToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	body := decodeBody(t, resp)
+	promptID := body["prompt"].(map[string]any)["id"].(string)
+	resp.Body.Close()
+
+	// 5. Viewer cannot delete prompt (Forbidden)
+	req = newReq(t, http.MethodDelete, fmt.Sprintf("/v1/prompts/%s", promptID), "", viewerToken)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	resp.Body.Close()
+
+	// 6. Editor can delete prompt (Success)
+	req = newReq(t, http.MethodDelete, fmt.Sprintf("/v1/prompts/%s", promptID), "", editorToken)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
+	// 7. Try to delete already deleted prompt (Not Found)
+	req = newReq(t, http.MethodDelete, fmt.Sprintf("/v1/prompts/%s", promptID), "", editorToken)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+}
+
 func TestRestorePrompt(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)

--- a/internal/handler/prompt_test.go
+++ b/internal/handler/prompt_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/px0-ai/px0/internal/search"
+	"github.com/px0-ai/px0/internal/searchfactory"
 	"github.com/px0-ai/px0/internal/store"
 )
 
@@ -64,6 +66,8 @@ func TestCreatePrompt_Conflict(t *testing.T) {
 	resp.Body.Close()
 
 	// 1. Conflict on name
+	// Note: It is intentional that name/slug reuse is blocked globally across all statuses (including archived).
+	// This ensures `GET /v1/prompts/:slug` remains stable and never returns multiple rows or ambiguous results for historical lookups.
 	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
 		`{"name":"Unique Name","description":"different"}`, token)
 	resp, err = a.Test(req)
@@ -139,6 +143,65 @@ func TestListPrompts_Empty(t *testing.T) {
 	body := decodeBody(t, resp)
 	prompts := body["prompts"].([]any)
 	assert.Empty(t, prompts)
+}
+
+func TestListPrompts_Filters(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	// Create prompt 1: "billing"
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+		`{"name":"Support Bot","description":"Handles billing issues"}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Create prompt 2: "technical"
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+		`{"name":"Tech Bot","description":"Handles technical issues"}`, token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+
+	body := decodeBody(t, resp)
+	techPromptID := body["prompt"].(map[string]any)["id"].(string)
+
+	// 1. Search with Q=billing
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?q=billing", teamID), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body = decodeBody(t, resp)
+	prompts := body["prompts"].([]any)
+	assert.Len(t, prompts, 1)
+	assert.Equal(t, "Support Bot", prompts[0].(map[string]any)["name"])
+
+	// 2. Archive tech prompt
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", techPromptID), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// 3. Default search (should only return active: Support Bot)
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teamID), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body = decodeBody(t, resp)
+	prompts = body["prompts"].([]any)
+	assert.Len(t, prompts, 1)
+	assert.Equal(t, "Support Bot", prompts[0].(map[string]any)["name"])
+
+	// 4. Search with archived=true
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?archived=true", teamID), "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body = decodeBody(t, resp)
+	prompts = body["prompts"].([]any)
+	assert.Len(t, prompts, 1)
+	assert.Equal(t, "Tech Bot", prompts[0].(map[string]any)["name"])
 }
 
 func TestGetPrompt_Success(t *testing.T) {
@@ -623,3 +686,108 @@ func TestDiffVersions(t *testing.T) {
 	assert.Contains(t, body["diff"].(string), "Welcome to px0.")
 	resp.Body.Close()
 }
+
+func TestSearchPrompts_FTS(t *testing.T) {
+	// Enable postgres search provider for this test
+	t.Setenv("SEARCH_PROVIDER", "postgres")
+
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	// Build the real Postgres provider and wire it to search.Default
+	ctx := context.Background()
+	p, err := searchfactory.NewProvider(ctx)
+	require.NoError(t, err)
+	search.Init(p)
+
+	// Clean up global state after test
+	t.Cleanup(func() {
+		search.Init(search.NoopProvider{})
+	})
+
+	// Create 3 prompts with differing names/descriptions/status
+	// 1. Matches "database" in name (Highest rank)
+	req1 := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+		`{"name":"Relational Database Tutorial","description":"A guide to tables."}`, token)
+	resp1, err := a.Test(req1)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp1.StatusCode)
+	resp1.Body.Close()
+
+	// 2. Matches "database" in description (Medium rank)
+	req2 := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+		`{"name":"Active Record Guide","description":"How to query the database."}`, token)
+	resp2, err := a.Test(req2)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp2.StatusCode)
+	resp2.Body.Close()
+
+	// 3. Matches "database" in description, but is archived
+	req3 := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+		`{"name":"Legacy System Docs","description":"Details about old database."}`, token)
+	resp3, err := a.Test(req3)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp3.StatusCode)
+	body3 := decodeBody(t, resp3)
+	p3ID := body3["prompt"].(map[string]any)["id"].(string)
+	resp3.Body.Close()
+
+	// Archive the third prompt
+	reqArch := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", p3ID), "", token)
+	respArch, err := a.Test(reqArch)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, respArch.StatusCode)
+	respArch.Body.Close()
+
+	// --- Query 0: Search "database" with NO status filter → defaults to active, so 2 matches returned ---
+	reqSearch0 := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?q=database", teamID), "", token)
+	respSearch0, err := a.Test(reqSearch0)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, respSearch0.StatusCode)
+	bodySearch0 := decodeBody(t, respSearch0)
+	prompts0 := bodySearch0["prompts"].([]any)
+	// No status filter → defaults to active
+	require.Len(t, prompts0, 2)
+	respSearch0.Body.Close()
+
+	// --- Query 1: Search "database" with status=active → only the 2 active prompts, rank-ordered ---
+	reqSearch1 := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?q=database&status=active", teamID), "", token)
+	respSearch1, err := a.Test(reqSearch1)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, respSearch1.StatusCode)
+
+	bodySearch1 := decodeBody(t, respSearch1)
+	prompts1 := bodySearch1["prompts"].([]any)
+	require.Len(t, prompts1, 2)
+
+	// Rank order: Prompt 1 ("Relational Database Tutorial") matches "database" in Name (Weight A).
+	// Prompt 2 ("Active Record Guide") matches in Description (Weight B). Prompt 1 must rank first.
+	assert.Equal(t, "Relational Database Tutorial", prompts1[0].(map[string]any)["name"])
+	assert.Equal(t, "Active Record Guide", prompts1[1].(map[string]any)["name"])
+	respSearch1.Body.Close()
+
+	// --- Query 2: Search for "database" with status=archived (should return the archived matching prompt) ---
+	reqSearch2 := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?q=database&status=archived", teamID), "", token)
+	respSearch2, err := a.Test(reqSearch2)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, respSearch2.StatusCode)
+
+	bodySearch2 := decodeBody(t, respSearch2)
+	prompts2 := bodySearch2["prompts"].([]any)
+	require.Len(t, prompts2, 1)
+	assert.Equal(t, "Legacy System Docs", prompts2[0].(map[string]any)["name"])
+	assert.Equal(t, p3ID, prompts2[0].(map[string]any)["id"].(string))
+	respSearch2.Body.Close()
+
+	// --- Query 3: Search for "database" with no matches ---
+	reqSearch3 := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?q=nonexistentkeyword", teamID), "", token)
+	respSearch3, err := a.Test(reqSearch3)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, respSearch3.StatusCode)
+
+	bodySearch3 := decodeBody(t, respSearch3)
+	assert.Empty(t, bodySearch3["prompts"].([]any))
+	respSearch3.Body.Close()
+}
+

--- a/internal/handler/prompt_test.go
+++ b/internal/handler/prompt_test.go
@@ -860,3 +860,35 @@ func TestSearchPrompts_FTS(t *testing.T) {
 	respSearch3.Body.Close()
 }
 
+func TestListPrompts_InvalidVector(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?vector=abc", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Contains(t, body["error"], "invalid vector parameter")
+}
+
+func TestListPrompts_VectorUnsupportedProvider(t *testing.T) {
+	// Active provider is NoopProvider by default in tests
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	teamID := setupUserTeam(t, token)
+
+	setupPrompt(t, a, token)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts?vector=0.1,0.2,0.3", teamID), "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	// Should fall back to store.ListPrompts and return OK
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodeBody(t, resp)
+	prompts := body["prompts"].([]any)
+	assert.Len(t, prompts, 1)
+}
+

--- a/internal/handler/tag.go
+++ b/internal/handler/tag.go
@@ -40,7 +40,8 @@ func SetTag(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	prompt, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs)
+	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -80,6 +81,8 @@ func SetTag(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
+	syncPromptSearchIndex(c.Context(), prompt)
+
 	return c.JSON(fiber.Map{"version": updatedVersion})
 }
 
@@ -110,7 +113,8 @@ func RemoveTag(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	prompt, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs)
+	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -124,6 +128,8 @@ func RemoveTag(c *fiber.Ctx) error {
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
+
+	syncPromptSearchIndex(c.Context(), prompt)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/handler/version.go
+++ b/internal/handler/version.go
@@ -383,7 +383,8 @@ func DeleteVersion(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	prompt, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs)
+	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -408,6 +409,8 @@ func DeleteVersion(c *fiber.Ctx) error {
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
+
+	syncPromptSearchIndex(c.Context(), prompt)
 
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/search/decorator.go
+++ b/internal/search/decorator.go
@@ -1,0 +1,42 @@
+package search
+
+import "context"
+
+// embeddingDecorator wraps a Provider. It exists to give the vector
+// provider a place to auto-embed prompts on the Index() mutation path
+// (so callers don't have to compute embeddings themselves).
+//
+// Search() is a pure pass-through: it does NOT auto-embed text queries
+// into vectors. Auto-embedding on the search path was a bug — it made
+// mode=fts silently do vector search when an embedder was registered
+// and gave callers no way to ask for FTS-only behaviour. Embedding for
+// search is now the caller's responsibility (see
+// internal/handler/prompt.go:resolveVectorFromQuery, which is the
+// only place a text query is converted to a vector for search).
+type embeddingDecorator struct {
+	Provider
+}
+
+// Search delegates to the underlying Provider with no embedding side
+// effect. The caller's SearchQuery.Vector is passed through unchanged.
+func (d embeddingDecorator) Search(ctx context.Context, q SearchQuery) ([]SearchResult, error) {
+	return d.Provider.Search(ctx, q)
+}
+
+// Index intercepts the prompt, generates an embedding if an active
+// Embedder exists, and delegates to the underlying Provider. This is
+// the only place auto-embed is allowed to happen, and it only happens
+// on the mutation path (writing a prompt to the vector store), not on
+// the query path.
+func (d embeddingDecorator) Index(ctx context.Context, p IndexablePrompt) error {
+	embedder := GetEmbedder()
+	if len(p.Embedding) == 0 && embedder != nil {
+		// We embed the name and description to capture the semantics of the prompt
+		vector, err := embedder.Embed(ctx, p.Name+" "+p.Description)
+		if err != nil {
+			return err
+		}
+		p.Embedding = vector
+	}
+	return d.Provider.Index(ctx, p)
+}

--- a/internal/search/embed.go
+++ b/internal/search/embed.go
@@ -1,0 +1,22 @@
+package search
+
+import "context"
+
+// Embedder generates vector embeddings for text.
+// This interface allows us to easily swap out embedding models (HuggingFace, OpenAI, local)
+// without changing the application logic.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+}
+
+var activeEmbedder Embedder
+
+// SetEmbedder configures the global embedding provider.
+func SetEmbedder(e Embedder) {
+	activeEmbedder = e
+}
+
+// GetEmbedder returns the active embedding provider.
+func GetEmbedder() Embedder {
+	return activeEmbedder
+}

--- a/internal/search/errors.go
+++ b/internal/search/errors.go
@@ -1,0 +1,9 @@
+package search
+
+import "errors"
+
+var (
+	// ErrProviderNotConfigured is returned by the factory (Phase 2) when the
+	// SEARCH_PROVIDER env var holds a value with no registered implementation.
+	ErrProviderNotConfigured = errors.New("search provider not configured")
+)

--- a/internal/search/errors.go
+++ b/internal/search/errors.go
@@ -6,4 +6,8 @@ var (
 	// ErrProviderNotConfigured is returned by the factory (Phase 2) when the
 	// SEARCH_PROVIDER env var holds a value with no registered implementation.
 	ErrProviderNotConfigured = errors.New("search provider not configured")
+
+	// ErrVectorSearchNotSupported is returned by providers that only support
+	// keyword/FTS search when the caller passes a non-nil SearchQuery.Vector.
+	ErrVectorSearchNotSupported = errors.New("vector search not supported by this provider")
 )

--- a/internal/search/global.go
+++ b/internal/search/global.go
@@ -1,0 +1,27 @@
+package search
+
+import (
+	"sync/atomic"
+)
+
+var defaultProvider atomic.Pointer[Provider]
+
+func init() {
+	// Start safely with a NoopProvider so we never panic on a nil dereference
+	// before main.go finishes initialization.
+	var p Provider = NoopProvider{}
+	defaultProvider.Store(&p)
+}
+
+// Get returns the active search provider for the process.
+// It is lock-free, safe for concurrent reads, and guaranteed to never return nil.
+func Get() Provider {
+	return *defaultProvider.Load()
+}
+
+// Init initialises the package-level default provider using the given Provider.
+// The provider is constructed by searchfactory.NewProvider() in main.go, which
+// keeps the import graph cycle-free (search/postgres → search, searchfactory → both).
+func Init(p Provider) {
+	defaultProvider.Store(&p)
+}

--- a/internal/search/global.go
+++ b/internal/search/global.go
@@ -4,24 +4,44 @@ import (
 	"sync/atomic"
 )
 
-var defaultProvider atomic.Pointer[Provider]
+var (
+	defaultFTSProvider     atomic.Pointer[Provider]
+	defaultVectorProvider   atomic.Pointer[Provider]
+)
 
 func init() {
-	// Start safely with a NoopProvider so we never panic on a nil dereference
+	// Start safely with NoopProviders so we never panic on a nil dereference
 	// before main.go finishes initialization.
 	var p Provider = NoopProvider{}
-	defaultProvider.Store(&p)
+	defaultFTSProvider.Store(&p)
+	defaultVectorProvider.Store(&p)
 }
 
-// Get returns the active search provider for the process.
+// GetFTS returns the active FTS search provider for the process.
 // It is lock-free, safe for concurrent reads, and guaranteed to never return nil.
-func Get() Provider {
-	return *defaultProvider.Load()
+func GetFTS() Provider {
+	return *defaultFTSProvider.Load()
 }
 
-// Init initialises the package-level default provider using the given Provider.
-// The provider is constructed by searchfactory.NewProvider() in main.go, which
-// keeps the import graph cycle-free (search/postgres → search, searchfactory → both).
-func Init(p Provider) {
-	defaultProvider.Store(&p)
+// GetVector returns the active vector search provider for the process.
+// It is lock-free, safe for concurrent reads, and guaranteed to never return nil.
+func GetVector() Provider {
+	return *defaultVectorProvider.Load()
+}
+
+// Init initialises the package-level FTS and vector providers.
+//
+// The two slots are independent: the FTS provider (e.g. postgres FTS) is
+// installed unwrapped because its Index is already a no-op and auto-embed
+// on the search path is the bug this refactor fixes. The vector provider
+// is wrapped in embeddingDecorator so that the handler can still rely on
+// Index() uploading an embedding when one is available — but Search()
+// does NOT auto-embed (see decorator.go).
+func Init(fts Provider, vector Provider) {
+	// FTS is installed as-is. Wrapping it with the embedding decorator
+	// has no effect on Search (which we just made a pass-through) and
+	// would only add confusion, since FTS providers don't consume vectors.
+	defaultFTSProvider.Store(&fts)
+	var wrappedVector Provider = embeddingDecorator{Provider: vector}
+	defaultVectorProvider.Store(&wrappedVector)
 }

--- a/internal/search/noop.go
+++ b/internal/search/noop.go
@@ -15,9 +15,6 @@ var _ Provider = NoopProvider{}
 type NoopProvider struct{}
 
 func (NoopProvider) Search(_ context.Context, q SearchQuery) ([]SearchResult, error) {
-	if q.Vector != nil {
-		return nil, ErrVectorSearchNotSupported
-	}
 	return nil, ErrNotImplemented
 }
 

--- a/internal/search/noop.go
+++ b/internal/search/noop.go
@@ -14,7 +14,10 @@ var _ Provider = NoopProvider{}
 // Use it in tests or as a stand-in while implementing a real provider.
 type NoopProvider struct{}
 
-func (NoopProvider) Search(_ context.Context, _ SearchQuery) ([]SearchResult, error) {
+func (NoopProvider) Search(_ context.Context, q SearchQuery) ([]SearchResult, error) {
+	if q.Vector != nil {
+		return nil, ErrVectorSearchNotSupported
+	}
 	return nil, ErrNotImplemented
 }
 

--- a/internal/search/noop.go
+++ b/internal/search/noop.go
@@ -1,0 +1,27 @@
+package search
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Compile-time assertion: NoopProvider must implement Provider.
+// If the interface changes and NoopProvider drifts, this line will not compile.
+var _ Provider = NoopProvider{}
+
+// NoopProvider satisfies Provider with silent no-ops.
+// Use it in tests or as a stand-in while implementing a real provider.
+type NoopProvider struct{}
+
+func (NoopProvider) Search(_ context.Context, _ SearchQuery) ([]SearchResult, error) {
+	return nil, ErrNotImplemented
+}
+
+func (NoopProvider) Index(_ context.Context, _ IndexablePrompt) error {
+	return nil
+}
+
+func (NoopProvider) Deindex(_ context.Context, _ uuid.UUID) error {
+	return nil
+}

--- a/internal/search/noop_test.go
+++ b/internal/search/noop_test.go
@@ -11,11 +11,22 @@ import (
 // Compile-time check: NoopProvider must satisfy Provider interface
 var _ Provider = (*NoopProvider)(nil)
 
-func TestNoopProvider_Search(t *testing.T) {
+func TestNoopProvider_Search_TextQuery(t *testing.T) {
 	p := &NoopProvider{}
 	results, err := p.Search(context.Background(), SearchQuery{Q: "test"})
 	if !errors.Is(err, ErrNotImplemented) {
 		t.Fatalf("expected ErrNotImplemented, got %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestNoopProvider_Search_VectorQuery(t *testing.T) {
+	p := &NoopProvider{}
+	results, err := p.Search(context.Background(), SearchQuery{Vector: []float32{1.0, 2.0}})
+	if !errors.Is(err, ErrVectorSearchNotSupported) {
+		t.Fatalf("expected ErrVectorSearchNotSupported, got %v", err)
 	}
 	if len(results) != 0 {
 		t.Fatalf("expected empty results, got %d", len(results))

--- a/internal/search/noop_test.go
+++ b/internal/search/noop_test.go
@@ -1,0 +1,39 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Compile-time check: NoopProvider must satisfy Provider interface
+var _ Provider = (*NoopProvider)(nil)
+
+func TestNoopProvider_Search(t *testing.T) {
+	p := &NoopProvider{}
+	results, err := p.Search(context.Background(), SearchQuery{Q: "test"})
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("expected ErrNotImplemented, got %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestNoopProvider_Index(t *testing.T) {
+	p := &NoopProvider{}
+	err := p.Index(context.Background(), IndexablePrompt{ID: uuid.New()})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestNoopProvider_Deindex(t *testing.T) {
+	p := &NoopProvider{}
+	err := p.Deindex(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}

--- a/internal/search/noop_test.go
+++ b/internal/search/noop_test.go
@@ -25,8 +25,8 @@ func TestNoopProvider_Search_TextQuery(t *testing.T) {
 func TestNoopProvider_Search_VectorQuery(t *testing.T) {
 	p := &NoopProvider{}
 	results, err := p.Search(context.Background(), SearchQuery{Vector: []float32{1.0, 2.0}})
-	if !errors.Is(err, ErrVectorSearchNotSupported) {
-		t.Fatalf("expected ErrVectorSearchNotSupported, got %v", err)
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("expected ErrNotImplemented, got %v", err)
 	}
 	if len(results) != 0 {
 		t.Fatalf("expected empty results, got %d", len(results))

--- a/internal/search/postgres/provider.go
+++ b/internal/search/postgres/provider.go
@@ -1,0 +1,86 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/px0-ai/px0/internal/db"
+	"github.com/px0-ai/px0/internal/search"
+)
+
+// Compile-time assertion: Provider must implement search.Provider.
+var _ search.Provider = &Provider{}
+
+// Provider implements search.Provider using PostgreSQL Full-Text Search.
+// It uses a pre-computed tsvector column (search_vector) maintained by a
+// database trigger, queried via websearch_to_tsquery for natural-language input.
+type Provider struct{}
+
+// NewProvider returns a Postgres-backed search.Provider.
+// Requires db.Pool to already be initialised (called after db.Connect in main.go).
+func NewProvider() search.Provider {
+	return &Provider{}
+}
+
+// Search runs a full-text query against the prompts table.
+// When q.Q is empty it returns nil immediately — the caller (handler) falls
+// back to the regular store.ListPrompts path.
+// Status is applied as a WHERE clause when non-nil (early DB-level filter).
+func (p *Provider) Search(ctx context.Context, q search.SearchQuery) ([]search.SearchResult, error) {
+	if q.Q == "" {
+		return nil, nil
+	}
+	if len(q.TeamIDs) == 0 {
+		return nil, nil
+	}
+
+	args := []any{q.Q, q.TeamIDs}
+	clauses := []string{
+		"team_id = ANY($2)",
+		"search_vector @@ websearch_to_tsquery('english', $1)",
+	}
+
+	// Optional status filter — reduces result set before ID hydration.
+	if q.Status != nil {
+		args = append(args, *q.Status)
+		clauses = append(clauses, fmt.Sprintf("status = $%d", len(args)))
+	}
+
+	query := fmt.Sprintf(`
+		SELECT id, ts_rank(search_vector, websearch_to_tsquery('english', $1)) AS score
+		FROM prompts
+		WHERE %s
+		ORDER BY score DESC
+	`, strings.Join(clauses, " AND "))
+
+	rows, err := db.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres search: %w", err)
+	}
+	defer rows.Close()
+
+	var results []search.SearchResult
+	for rows.Next() {
+		var r search.SearchResult
+		if err := rows.Scan(&r.PromptID, &r.Score); err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
+// Index is a no-op for Postgres FTS — the search_vector column is kept
+// up to date automatically by the database trigger on every INSERT/UPDATE.
+func (p *Provider) Index(_ context.Context, _ search.IndexablePrompt) error {
+	return nil
+}
+
+// Deindex is a no-op for Postgres FTS — cascade deletes on the prompts
+// table remove the row and its tsvector automatically.
+func (p *Provider) Deindex(_ context.Context, _ uuid.UUID) error {
+	return nil
+}

--- a/internal/search/postgres/provider.go
+++ b/internal/search/postgres/provider.go
@@ -30,6 +30,9 @@ func NewProvider() search.Provider {
 // back to the regular store.ListPrompts path.
 // Status is applied as a WHERE clause when non-nil (early DB-level filter).
 func (p *Provider) Search(ctx context.Context, q search.SearchQuery) ([]search.SearchResult, error) {
+	if q.Vector != nil {
+		return nil, search.ErrVectorSearchNotSupported
+	}
 	if q.Q == "" {
 		return nil, nil
 	}

--- a/internal/search/postgres/provider.go
+++ b/internal/search/postgres/provider.go
@@ -25,9 +25,30 @@ func NewProvider() search.Provider {
 	return &Provider{}
 }
 
-// Search runs a full-text query against the prompts table.
-// When q.Q is empty it returns nil immediately — the caller (handler) falls
-// back to the regular store.ListPrompts path.
+// minFTSRank is the minimum ts_rank score required for a result to be
+// included. With OR semantics, a query can match many documents via a
+// single common lexeme (e.g. "help" matching "Helps" in a description).
+// This threshold filters out coincidental single-term description hits
+// while allowing multi-term matches and weighted name matches to surface.
+//
+// Empirically, with weight A=1.0 (name) and B=0.4 (description):
+//   - Single term in description only: ≈0.10-0.12 → filtered
+//   - Two+ terms in description:       ≈0.20-0.30 → included
+//   - Single term in name (weight A):  ≈0.30+     → included
+//
+// At 0.15, queries like "quantum physics homework help" that match only
+// via a coincidental "help" lexeme are safely excluded, while "app keeps
+// crashing" returns prompts with 2+ matching tokens.
+const minFTSRank = 0.15
+
+// Search runs a full-text query against the prompts table using OR
+// semantics: the query is tokenized by websearch_to_tsquery and then
+// AND operators are replaced with OR so a document matches if ANY
+// query term is present. Results are ranked by ts_rank and filtered
+// to a minimum relevance floor.
+//
+// When q.Q is empty it returns nil immediately — the caller (handler)
+// falls back to the regular store.ListPrompts path.
 // Status is applied as a WHERE clause when non-nil (early DB-level filter).
 func (p *Provider) Search(ctx context.Context, q search.SearchQuery) ([]search.SearchResult, error) {
 	if q.Vector != nil {
@@ -41,23 +62,30 @@ func (p *Provider) Search(ctx context.Context, q search.SearchQuery) ([]search.S
 	}
 
 	args := []any{q.Q, q.TeamIDs}
-	clauses := []string{
+	whereClauses := []string{
 		"team_id = ANY($2)",
-		"search_vector @@ websearch_to_tsquery('english', $1)",
+		"search_vector @@ q.tsq",
 	}
 
-	// Optional status filter — reduces result set before ID hydration.
 	if q.Status != nil {
 		args = append(args, *q.Status)
-		clauses = append(clauses, fmt.Sprintf("status = $%d", len(args)))
+		whereClauses = append(whereClauses, fmt.Sprintf("status = $%d", len(args)))
 	}
 
 	query := fmt.Sprintf(`
-		SELECT id, ts_rank(search_vector, websearch_to_tsquery('english', $1)) AS score
-		FROM prompts
-		WHERE %s
+		WITH q AS (
+			SELECT replace(websearch_to_tsquery('english', $1)::text, ' & ', ' | ')::tsquery AS tsq
+		),
+		ranked AS (
+			SELECT id, ts_rank(search_vector, q.tsq) AS score
+			FROM prompts, q
+			WHERE %s
+		)
+		SELECT id, score
+		FROM ranked
+		WHERE score >= %f
 		ORDER BY score DESC
-	`, strings.Join(clauses, " AND "))
+	`, strings.Join(whereClauses, " AND "), minFTSRank)
 
 	rows, err := db.Pool.Query(ctx, query, args...)
 	if err != nil {

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -25,6 +25,15 @@ type SearchQuery struct {
 
 	// Status optionally filters by prompt status ("active", "archived").
 	Status *string
+
+	// Vector is a pre-computed query embedding for vector-similarity search.
+	// When non-nil, providers that support vector search MUST use it.
+	// When nil, providers fall back to keyword/FTS search on Q.
+	Vector []float32
+
+	// TopK limits the number of vector results returned (default: 10).
+	// Ignored by FTS providers.
+	TopK int
 }
 
 // SearchResult is a single hit returned by the provider.
@@ -36,6 +45,10 @@ type SearchResult struct {
 	// External providers (Algolia, ES) return their own native scores.
 	// Zero means the provider does not support scoring.
 	Score float64
+
+	// Distance is the vector similarity distance from the query embedding.
+	// Lower is more similar. Zero means the provider is FTS-only.
+	Distance float32
 }
 
 // IndexablePrompt is the minimal document shape passed to Index / Deindex.
@@ -49,6 +62,11 @@ type IndexablePrompt struct {
 	Slug        string
 	Status      string
 	Tags        []string
+
+	// Embedding is the pre-computed vector representation of this prompt.
+	// Nil means the caller did not supply an embedding (e.g. Postgres FTS path).
+	// External vector providers (Qdrant, Pinecone) use this during Index().
+	Embedding []float32
 }
 
 // Provider is the contract every search backend must implement.

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -1,0 +1,75 @@
+package search
+
+import (
+	"context"
+
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+var ErrNotImplemented = errors.New("search provider not implemented")
+
+// SearchQuery holds the parameters a caller can pass to search for prompts.
+// All fields are optional — an empty Q with TeamIDs returns all accessible prompts.
+type SearchQuery struct {
+	// Q is the free-text search term applied across name, description, and slug.
+	Q string
+
+	// TeamIDs scopes the search to the given teams (enforces tenancy isolation).
+	// Every provider implementation is responsible for scoping to these IDs.
+	TeamIDs []uuid.UUID
+
+	// Tags optionally narrows results to prompts carrying all listed tags.
+	Tags []string
+
+	// Status optionally filters by prompt status ("active", "archived").
+	Status *string
+}
+
+// SearchResult is a single hit returned by the provider.
+type SearchResult struct {
+	PromptID uuid.UUID
+
+	// Score is the relevance ranking from the provider.
+	// Postgres FTS populates this via ts_rank.
+	// External providers (Algolia, ES) return their own native scores.
+	// Zero means the provider does not support scoring.
+	Score float64
+}
+
+// IndexablePrompt is the minimal document shape passed to Index / Deindex.
+// Kept separate from model.Prompt to avoid a dependency on the model package
+// and to keep this package importable by future external SDK clients.
+type IndexablePrompt struct {
+	ID          uuid.UUID
+	TeamID      uuid.UUID
+	Name        string
+	Description string
+	Slug        string
+	Status      string
+	Tags        []string
+}
+
+// Provider is the contract every search backend must implement.
+//
+// It has two sides:
+//   - Query side    → Search()
+//   - Mutation side → Index(), Deindex()
+//
+// For Postgres FTS, Index and Deindex are no-ops because the live table
+// columns are the index. For external providers (Algolia, ES, OpenSearch),
+// they push/remove documents from the external index.
+type Provider interface {
+	// Search executes a query and returns an ordered list of matching results.
+	// Results are ordered by relevance score descending.
+	Search(ctx context.Context, q SearchQuery) ([]SearchResult, error)
+
+	// Index adds or updates a prompt document in the search index.
+	// Must be called after a prompt is created or updated.
+	Index(ctx context.Context, p IndexablePrompt) error
+
+	// Deindex removes a prompt document from the search index.
+	// Must be called after a prompt is deleted or archived.
+	Deindex(ctx context.Context, promptID uuid.UUID) error
+}

--- a/internal/searchfactory/factory.go
+++ b/internal/searchfactory/factory.go
@@ -1,0 +1,48 @@
+// Package searchfactory constructs the active search.Provider from environment
+// configuration. It lives in its own package to avoid an import cycle:
+//
+//	search/postgres → search (interface)
+//	searchfactory   → search + search/postgres   (no cycle)
+package searchfactory
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/px0-ai/px0/internal/search"
+	pgprovider "github.com/px0-ai/px0/internal/search/postgres"
+)
+
+// NewProvider reads the SEARCH_PROVIDER environment variable and returns
+// the appropriate search.Provider implementation.
+//
+// Supported values:
+//   - "postgres"      → PostgreSQL Full-Text Search
+//   - "elasticsearch" → Elasticsearch (not yet implemented)
+//   - "opensearch"    → OpenSearch    (not yet implemented)
+//   - "algolia"       → Algolia       (not yet implemented)
+//   - ""              → defaults to NoopProvider with a warning
+//
+// If SEARCH_PROVIDER is set to a known-but-unimplemented provider, it returns
+// search.ErrProviderNotConfigured so the caller can decide whether to fatal or warn.
+func NewProvider(_ context.Context) (search.Provider, error) {
+	name := os.Getenv("SEARCH_PROVIDER")
+
+	switch name {
+	case "", "noop":
+		log.Println("warn: SEARCH_PROVIDER not set, search is disabled (using noop)")
+		return search.NoopProvider{}, nil
+
+	case "postgres":
+		log.Println("info: using postgres full-text search provider")
+		return pgprovider.NewProvider(), nil
+
+	case "elasticsearch", "opensearch", "algolia":
+		return nil, fmt.Errorf("%w: %q", search.ErrProviderNotConfigured, name)
+
+	default:
+		return nil, fmt.Errorf("%w: unknown provider %q", search.ErrProviderNotConfigured, name)
+	}
+}

--- a/internal/searchfactory/factory.go
+++ b/internal/searchfactory/factory.go
@@ -23,6 +23,8 @@ import (
 //   - "elasticsearch" → Elasticsearch (not yet implemented)
 //   - "opensearch"    → OpenSearch    (not yet implemented)
 //   - "algolia"       → Algolia       (not yet implemented)
+//   - "qdrant"        → Qdrant Vector Search (not yet implemented)
+//   - "pinecone"      → Pinecone Vector Search (not yet implemented)
 //   - ""              → defaults to NoopProvider with a warning
 //
 // If SEARCH_PROVIDER is set to a known-but-unimplemented provider, it returns
@@ -39,7 +41,7 @@ func NewProvider(_ context.Context) (search.Provider, error) {
 		log.Println("info: using postgres full-text search provider")
 		return pgprovider.NewProvider(), nil
 
-	case "elasticsearch", "opensearch", "algolia":
+	case "elasticsearch", "opensearch", "algolia", "qdrant", "pinecone":
 		return nil, fmt.Errorf("%w: %q", search.ErrProviderNotConfigured, name)
 
 	default:

--- a/internal/searchfactory/factory_test.go
+++ b/internal/searchfactory/factory_test.go
@@ -1,0 +1,251 @@
+package searchfactory_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/px0-ai/px0/internal/search"
+	"github.com/px0-ai/px0/internal/searchfactory"
+)
+
+// TestNewFTSProvider_Default verifies that an unset SEARCH_FTS_PROVIDER
+// resolves to a no-op provider rather than erroring out. This is the
+// "out of the box" experience the issue asks for: starting the server
+// without any config should not fail.
+func TestNewFTSProvider_Default(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+	t.Setenv("SEARCH_PROVIDER", "")
+
+	p, err := searchfactory.NewFTSProvider(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected a non-nil provider")
+	}
+	// The noop provider reports ErrNotImplemented for any search.
+	_, err = p.Search(context.Background(), search.SearchQuery{Q: "anything"})
+	if !errors.Is(err, search.ErrNotImplemented) {
+		t.Fatalf("expected NoopProvider to return ErrNotImplemented, got %v", err)
+	}
+}
+
+// TestNewFTSProvider_Postgres verifies that SEARCH_FTS_PROVIDER=postgres
+// resolves to a real (non-noop) provider.
+func TestNewFTSProvider_Postgres(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "postgres")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+	t.Setenv("SEARCH_PROVIDER", "")
+
+	p, err := searchfactory.NewFTSProvider(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	// The noop provider would return ErrNotImplemented for any query;
+	// the real postgres provider returns nil, nil when the Q is empty
+	// (so we can detect the difference even without a database).
+	results, err := p.Search(context.Background(), search.SearchQuery{Q: ""})
+	if err != nil {
+		t.Fatalf("postgres provider should not error on empty Q, got %v", err)
+	}
+	if results != nil {
+		t.Fatalf("postgres provider should return nil results for empty Q, got %v", results)
+	}
+}
+
+// TestNewFTSProvider_Noop verifies SEARCH_FTS_PROVIDER=noop returns
+// a no-op explicitly.
+func TestNewFTSProvider_Noop(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "noop")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+	t.Setenv("SEARCH_PROVIDER", "")
+
+	p, err := searchfactory.NewFTSProvider(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	_, err = p.Search(context.Background(), search.SearchQuery{Q: "x"})
+	if !errors.Is(err, search.ErrNotImplemented) {
+		t.Fatalf("expected NoopProvider, got %v", err)
+	}
+}
+
+// TestNewFTSProvider_UnknownErrors verifies that unknown FTS providers
+// surface as ErrProviderNotConfigured.
+func TestNewFTSProvider_UnknownErrors(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+	t.Setenv("SEARCH_PROVIDER", "wat-is-this")
+
+	_, err := searchfactory.NewFTSProvider(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for an unknown legacy value")
+	}
+	if !errors.Is(err, search.ErrProviderNotConfigured) {
+		t.Fatalf("expected ErrProviderNotConfigured, got %v", err)
+	}
+}
+
+// TestNewFTSProvider_UnimplementedStubErrors verifies that known-but-
+// unimplemented values return ErrProviderNotConfigured rather than
+// silently falling back to noop.
+func TestNewFTSProvider_UnimplementedStubErrors(t *testing.T) {
+	for _, name := range []string{"elasticsearch", "opensearch", "algolia"} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("SEARCH_FTS_PROVIDER", name)
+			t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+			t.Setenv("SEARCH_PROVIDER", "")
+
+			_, err := searchfactory.NewFTSProvider(context.Background())
+			if err == nil {
+				t.Fatalf("expected an error for stub provider %q", name)
+			}
+			if !errors.Is(err, search.ErrProviderNotConfigured) {
+				t.Fatalf("expected ErrProviderNotConfigured for %q, got %v", name, err)
+			}
+		})
+	}
+}
+
+// TestNewVectorProvider_Default verifies the same default-to-noop
+// behaviour for the vector slot.
+func TestNewVectorProvider_Default(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+	t.Setenv("SEARCH_PROVIDER", "")
+
+	p, err := searchfactory.NewVectorProvider(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	_, err = p.Search(context.Background(), search.SearchQuery{Vector: []float32{0.1}})
+	if !errors.Is(err, search.ErrNotImplemented) {
+		t.Fatalf("expected NoopProvider, got %v", err)
+	}
+}
+
+// TestNewVectorProvider_PineconeStubErrors verifies that pinecone
+// (not yet implemented) returns ErrProviderNotConfigured.
+func TestNewVectorProvider_PineconeStubErrors(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "pinecone")
+	t.Setenv("SEARCH_PROVIDER", "")
+
+	_, err := searchfactory.NewVectorProvider(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for pinecone (not yet implemented)")
+	}
+	if !errors.Is(err, search.ErrProviderNotConfigured) {
+		t.Fatalf("expected ErrProviderNotConfigured, got %v", err)
+	}
+}
+
+// TestNewVectorProvider_UnknownErrors verifies unknown vector values
+// surface as ErrProviderNotConfigured.
+func TestNewVectorProvider_UnknownErrors(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "wat-is-this")
+	t.Setenv("SEARCH_PROVIDER", "")
+
+	_, err := searchfactory.NewVectorProvider(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for unknown vector provider")
+	}
+	if !errors.Is(err, search.ErrProviderNotConfigured) {
+		t.Fatalf("expected ErrProviderNotConfigured, got %v", err)
+	}
+}
+
+// TestBackwardCompat_LegacySEARCH_PROVIDER_PostgresRoutesToFTS verifies
+// that an existing .env file with only SEARCH_PROVIDER=postgres still
+// produces a working FTS provider, exactly as it did before Phase 0.
+func TestBackwardCompat_LegacySEARCH_PROVIDER_PostgresRoutesToFTS(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+	t.Setenv("SEARCH_PROVIDER", "postgres")
+
+	fts, err := searchfactory.NewFTSProvider(context.Background())
+	if err != nil {
+		t.Fatalf("FTS provider should resolve via legacy var, got %v", err)
+	}
+	// Postgres FTS returns (nil, nil) for an empty Q (no FTS query, no error).
+	results, err := fts.Search(context.Background(), search.SearchQuery{Q: ""})
+	if err != nil {
+		t.Fatalf("postgres FTS should not error on empty Q, got %v", err)
+	}
+	if results != nil {
+		t.Fatalf("postgres FTS should return nil for empty Q, got %v", results)
+	}
+
+	// Vector side: the legacy "postgres" value should NOT be applied here.
+	vec, err := searchfactory.NewVectorProvider(context.Background())
+	if err != nil {
+		t.Fatalf("vector provider should still default to noop, got %v", err)
+	}
+	if vec == nil {
+		t.Fatal("expected a non-nil vector provider")
+	}
+	_, err = vec.Search(context.Background(), search.SearchQuery{Vector: []float32{0.1}})
+	if !errors.Is(err, search.ErrNotImplemented) {
+		t.Fatalf("vector slot should still be noop, got %v", err)
+	}
+}
+
+// TestBackwardCompat_LegacySEARCH_PROVIDER_QdrantRoutesToVector verifies
+// that the legacy SEARCH_PROVIDER=qdrant maps to the vector slot.
+func TestBackwardCompat_LegacySEARCH_PROVIDER_QdrantRoutesToVector(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "")
+	t.Setenv("SEARCH_PROVIDER", "qdrant")
+
+	// FTS side: qdrant is not FTS, so the FTS slot should fall back to
+	// noop rather than masquerading as FTS.
+	fts, err := searchfactory.NewFTSProvider(context.Background())
+	if err != nil {
+		t.Fatalf("FTS provider should not error on qdrant legacy, got %v", err)
+	}
+	_, err = fts.Search(context.Background(), search.SearchQuery{Q: "x"})
+	if !errors.Is(err, search.ErrNotImplemented) {
+		t.Fatalf("FTS slot should be noop when legacy=qdrant, got %v", err)
+	}
+
+	// Vector side: this WILL try to connect to qdrant. We can't
+	// guarantee a running qdrant here, so we only assert the error
+	// (if any) is NOT ErrProviderNotConfigured — it should be a
+	// connection error or nil, never a "not configured" error.
+	_, err = searchfactory.NewVectorProvider(context.Background())
+	if err == nil {
+		// If it succeeded, fine.
+		return
+	}
+	if errors.Is(err, search.ErrProviderNotConfigured) {
+		t.Fatalf("vector provider should resolve via legacy qdrant, got %v", err)
+	}
+	// Any other error (e.g. connection refused) is acceptable in test
+	// environments without a running qdrant.
+	if !strings.Contains(err.Error(), "connect") &&
+		!strings.Contains(err.Error(), "qdrant") {
+		t.Logf("note: legacy qdrant produced error %v (expected if no qdrant is running)", err)
+	}
+}
+
+// TestBackwardCompat_NewKeysWinOverLegacy verifies that when both the
+// new and legacy keys are set, the new key takes precedence.
+func TestBackwardCompat_NewKeysWinOverLegacy(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "noop")
+	t.Setenv("SEARCH_PROVIDER", "qdrant")
+
+	// New key takes precedence: vector is noop, even though legacy says qdrant.
+	p, err := searchfactory.NewVectorProvider(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	_, err = p.Search(context.Background(), search.SearchQuery{Vector: []float32{0.1}})
+	if !errors.Is(err, search.ErrNotImplemented) {
+		t.Fatalf("new key should win, expected noop, got %v", err)
+	}
+}

--- a/internal/store/prompt.go
+++ b/internal/store/prompt.go
@@ -20,6 +20,7 @@ type PromptFilter struct {
 	Archived *bool
 	Status   *string
 	Q        string
+	Limit    *int
 }
 
 func CreatePrompt(ctx context.Context, teamID uuid.UUID, slug, name, description string) (*model.Prompt, error) {
@@ -81,6 +82,11 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 		query += " WHERE " + strings.Join(whereClauses, " AND ")
 	}
 	query += " ORDER BY p.created_at DESC"
+
+	if filter.Limit != nil {
+		args = append(args, *filter.Limit)
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
 
 	rows, err := db.Pool.Query(ctx, query, args...)
 	if err != nil {

--- a/internal/store/prompt.go
+++ b/internal/store/prompt.go
@@ -190,6 +190,22 @@ func RestorePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) error
 	return nil
 }
 
+func DeletePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) error {
+	_, err := GetPromptByID(ctx, id, teamIDs)
+	if err != nil {
+		return err // ErrNotFound if not found or no access
+	}
+
+	result, err := db.Pool.Exec(ctx, "DELETE FROM prompts WHERE id = $1", id)
+	if err != nil {
+		return fmt.Errorf("delete prompt: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func MovePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID, targetTeamID uuid.UUID) error {
 	_, err := GetPromptByID(ctx, id, teamIDs)
 	if err != nil {

--- a/internal/store/prompt.go
+++ b/internal/store/prompt.go
@@ -19,6 +19,7 @@ type PromptFilter struct {
 	Tags     []string
 	Archived *bool
 	Status   *string
+	Q        string
 }
 
 func CreatePrompt(ctx context.Context, teamID uuid.UUID, slug, name, description string) (*model.Prompt, error) {
@@ -55,6 +56,12 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 	if len(filter.TeamIDs) > 0 {
 		args = append(args, filter.TeamIDs)
 		whereClauses = append(whereClauses, fmt.Sprintf("p.team_id = ANY($%d)", len(args)))
+	}
+
+	if filter.Q != "" {
+		args = append(args, "%"+filter.Q+"%")
+		param := fmt.Sprintf("$%d", len(args))
+		whereClauses = append(whereClauses, fmt.Sprintf("(p.name ILIKE %s OR p.description ILIKE %s)", param, param))
 	}
 
 	if filter.Status != nil {
@@ -195,3 +202,54 @@ func MovePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID, targetTe
 	}
 	return nil
 }
+
+// GetPromptsByIDs fetches full prompt records for the given IDs, scoped to
+// the provided teamIDs for tenancy isolation.
+//
+// An optional status filter is applied as a store-layer safety net — the
+// search provider may already have filtered by status, but we re-apply it
+// here for defense-in-depth correctness.
+//
+// The returned slice preserves the order of the input ids slice so that the
+// caller's score-based ranking (from the search provider) is maintained.
+func GetPromptsByIDs(ctx context.Context, ids []uuid.UUID, teamIDs []uuid.UUID, status *string) ([]*model.Prompt, error) {
+	args := []any{ids, teamIDs}
+	where := "id = ANY($1) AND team_id = ANY($2)"
+
+	if status != nil {
+		args = append(args, *status)
+		where += fmt.Sprintf(" AND status = $%d", len(args))
+	}
+
+	rows, err := db.Pool.Query(ctx,
+		fmt.Sprintf(`SELECT id, team_id, slug, name, description, status, created_at, updated_at
+		             FROM prompts WHERE %s`, where),
+		args...)
+	if err != nil {
+		return nil, fmt.Errorf("get prompts by ids: %w", err)
+	}
+	defer rows.Close()
+
+	byID := make(map[uuid.UUID]*model.Prompt, len(ids))
+	for rows.Next() {
+		p := &model.Prompt{}
+		if err := rows.Scan(&p.ID, &p.TeamID, &p.Slug, &p.Name, &p.Description,
+			&p.Status, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, err
+		}
+		byID[p.ID] = p
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Re-order to match the original ids slice (score order from search provider).
+	result := make([]*model.Prompt, 0, len(ids))
+	for _, id := range ids {
+		if p, ok := byID[id]; ok {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+

--- a/internal/store/prompt.go
+++ b/internal/store/prompt.go
@@ -41,7 +41,121 @@ func CreatePrompt(ctx context.Context, teamID uuid.UUID, slug, name, description
 	return p, nil
 }
 
+// minFTSScore is the minimum ts_rank below which a match is treated as
+// noise. Empirically, single-token english matches score in the
+// 0.05-0.30 range; multi-token queries score higher. Anything below
+// this is coincidental substring overlap with no real lexical match,
+// and returning it just inflates top_k with garbage.
+//
+// The threshold is a package-level constant rather than a query
+// parameter so the behaviour is stable across callers and tests.
+const minFTSScore = 0.05
+
+// ListPrompts performs PostgreSQL full-text search against the
+// `search_vector` tsvector column added in migration 020_prompts_fts.sql.
+// Weights are A=name, B=description, C=slug, as set up by the trigger.
+//
+// The function short-circuits to an empty result when filter.Q is empty
+// rather than relying on websearch_to_tsquery('') — the latter is
+// implementation-defined in PostgreSQL and can match arbitrary tokens.
+//
+// A minimum ts_rank threshold filters out coincidental matches; queries
+// with no real lexical overlap return an empty result set rather than
+// being padded to top_k with weak hits. This fixes the over-inclusion
+// behaviour of the previous ILIKE path, which returned every prompt
+// whose name or description merely contained the query as a substring.
+//
+// Results are ordered by ts_rank descending, with p.created_at as a
+// stable tiebreaker. Tags, status, team scope, and limit filters are
+// honoured the same way they were in the original implementation.
 func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, error) {
+	if filter.Q == "" {
+		return []*model.Prompt{}, nil
+	}
+
+	args := []any{filter.Q, filter.TeamIDs}
+	joins := ""
+	whereClauses := []string{
+		"p.team_id = ANY($2)",
+		"p.search_vector @@ q.tsq",
+	}
+
+	if len(filter.Tags) > 0 {
+		joins = " INNER JOIN prompt_tags pt ON pt.prompt_id = p.id"
+		args = append(args, filter.Tags)
+		whereClauses = append(whereClauses, fmt.Sprintf("pt.tag = ANY($%d)", len(args)))
+	}
+
+	if filter.Status != nil {
+		args = append(args, *filter.Status)
+		whereClauses = append(whereClauses, fmt.Sprintf("p.status = $%d", len(args)))
+	} else if filter.Archived != nil {
+		statusVal := model.PromptStatusActive
+		if *filter.Archived {
+			statusVal = model.PromptStatusArchived
+		}
+		args = append(args, statusVal)
+		whereClauses = append(whereClauses, fmt.Sprintf("p.status = $%d", len(args)))
+	}
+
+	limitClause := ""
+	if filter.Limit != nil {
+		args = append(args, *filter.Limit)
+		limitClause = fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+
+	// Two-stage CTE: scored computes the rank once, filtered dedupes
+	// (the tag join can multiply rows per id) and applies the minimum
+	// rank threshold, the outer SELECT re-sorts by rank descending.
+	// We can't fold ORDER BY into the DISTINCT statement because
+	// PostgreSQL requires every ORDER BY expression to appear in the
+	// SELECT list of a DISTINCT query, and we don't want to expose
+	// `score` in the output.
+	query := fmt.Sprintf(`
+		WITH q AS (SELECT websearch_to_tsquery('english', $1) AS tsq),
+		scored AS (
+			SELECT p.id, p.team_id, p.slug, p.name, p.description, p.status, p.created_at, p.updated_at,
+			       ts_rank(p.search_vector, q.tsq) AS score
+			FROM prompts p%s, q
+			WHERE %s
+		),
+		filtered AS (
+			SELECT DISTINCT ON (id) *
+			FROM scored
+			WHERE score >= %f
+			ORDER BY id, score DESC
+		)
+		SELECT id, team_id, slug, name, description, status, created_at, updated_at
+		FROM filtered
+		ORDER BY score DESC, created_at DESC%s
+	`, joins, strings.Join(whereClauses, " AND "), minFTSScore, limitClause)
+
+	rows, err := db.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list prompts: %w", err)
+	}
+	defer rows.Close()
+
+	var prompts []*model.Prompt
+	for rows.Next() {
+		p := &model.Prompt{}
+		if err := rows.Scan(&p.ID, &p.TeamID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, err
+		}
+		prompts = append(prompts, p)
+	}
+	return prompts, rows.Err()
+}
+
+// ListPromptsByFilter returns a non-search listing of prompts matching
+// the given filter. This is the unranked path used by the list endpoints
+// when the caller did not supply a ?q= query string.
+//
+// It is the unranked counterpart to ListPrompts: same filter surface
+// (team scope, status, archived, tags, limit) but no FTS, no ranking,
+// and no minimum-score threshold. The result is just a slice of prompts
+// ordered by created_at descending.
+func ListPromptsByFilter(ctx context.Context, filter PromptFilter) ([]*model.Prompt, error) {
 	query := `SELECT DISTINCT p.id, p.team_id, p.slug, p.name, p.description, p.status, p.created_at, p.updated_at
 			  FROM prompts p`
 	args := []any{}
@@ -57,12 +171,6 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 	if len(filter.TeamIDs) > 0 {
 		args = append(args, filter.TeamIDs)
 		whereClauses = append(whereClauses, fmt.Sprintf("p.team_id = ANY($%d)", len(args)))
-	}
-
-	if filter.Q != "" {
-		args = append(args, "%"+filter.Q+"%")
-		param := fmt.Sprintf("$%d", len(args))
-		whereClauses = append(whereClauses, fmt.Sprintf("(p.name ILIKE %s OR p.description ILIKE %s)", param, param))
 	}
 
 	if filter.Status != nil {
@@ -90,7 +198,7 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 
 	rows, err := db.Pool.Query(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("list prompts: %w", err)
+		return nil, fmt.Errorf("list prompts by filter: %w", err)
 	}
 	defer rows.Close()
 

--- a/internal/store/prompt_test.go
+++ b/internal/store/prompt_test.go
@@ -260,3 +260,32 @@ func TestUpdatePrompt(t *testing.T) {
 	_, err = store.UpdatePrompt(ctx, nonExistentUUID(), []uuid.UUID{tm.ID}, "Updated description")
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
+
+func TestDeletePrompt(t *testing.T) {
+	ctx := context.Background()
+	testutil.SetupDB(t)
+
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	p, err := store.CreatePrompt(ctx, tm.ID, "my_prompt", "My Prompt", "Initial description")
+	require.NoError(t, err)
+
+	// 1. Not found / Unauthorized team delete
+	otherTeam, err := store.CreateTeam(ctx, "Other Team")
+	require.NoError(t, err)
+	err = store.DeletePrompt(ctx, p.ID, []uuid.UUID{otherTeam.ID})
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	// 2. Success delete
+	err = store.DeletePrompt(ctx, p.ID, []uuid.UUID{tm.ID})
+	require.NoError(t, err)
+
+	// Verify it's actually deleted
+	_, err = store.GetPromptByID(ctx, p.ID, []uuid.UUID{tm.ID})
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	// 3. Try deleting non-existent prompt
+	err = store.DeletePrompt(ctx, nonExistentUUID(), []uuid.UUID{tm.ID})
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/internal/store/prompt_test.go
+++ b/internal/store/prompt_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -46,7 +47,7 @@ func TestCreatePrompt_Duplicate(t *testing.T) {
 	assert.ErrorIs(t, err, store.ErrDuplicate)
 }
 
-func TestListPrompts(t *testing.T) {
+func TestListPromptsByFilter(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	tm, err := store.CreateTeam(ctx, "Test Team")
@@ -57,20 +58,158 @@ func TestListPrompts(t *testing.T) {
 	_, err = store.CreatePrompt(ctx, tm.ID, "prompt_b", "Prompt B", "")
 	require.NoError(t, err)
 
-	prompts, err := store.ListPrompts(ctx, store.PromptFilter{TeamIDs: []uuid.UUID{tm.ID}})
+	prompts, err := store.ListPromptsByFilter(ctx, store.PromptFilter{TeamIDs: []uuid.UUID{tm.ID}})
 	require.NoError(t, err)
 	assert.Len(t, prompts, 2)
 }
 
-func TestListPrompts_Empty(t *testing.T) {
+func TestListPromptsByFilter_Empty(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	tm, err := store.CreateTeam(ctx, "Test Team")
 	require.NoError(t, err)
 
-	prompts, err := store.ListPrompts(ctx, store.PromptFilter{TeamIDs: []uuid.UUID{tm.ID}})
+	prompts, err := store.ListPromptsByFilter(ctx, store.PromptFilter{TeamIDs: []uuid.UUID{tm.ID}})
 	require.NoError(t, err)
 	assert.Empty(t, prompts)
+}
+
+func TestListPrompts_EmptyQueryReturnsEmpty(t *testing.T) {
+	// ListPrompts is the FTS function: an empty Q must short-circuit to
+	// an empty result set rather than relying on websearch_to_tsquery('')
+	// behaviour, which is implementation-defined.
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	_, err = store.CreatePrompt(ctx, tm.ID, "anything", "Anything", "Some description")
+	require.NoError(t, err)
+
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
+		TeamIDs: []uuid.UUID{tm.ID},
+		Q:       "",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, prompts, "empty Q must short-circuit to empty results")
+}
+
+func TestListPrompts_FTS_WeightedByField(t *testing.T) {
+	// Migration 020 assigns weight A to name, B to description, C to slug.
+	// A name-only match should outrank a description-only match for the
+	// same token, all other things being equal.
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	nameMatch, err := store.CreatePrompt(ctx, tm.ID, "alpha_slug", "Database Tutorial", "unrelated desc")
+	require.NoError(t, err)
+
+	descMatch, err := store.CreatePrompt(ctx, tm.ID, "other_slug", "Other Name", "mentions database")
+	require.NoError(t, err)
+
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
+		TeamIDs: []uuid.UUID{tm.ID},
+		Q:       "database",
+	})
+	require.NoError(t, err)
+	require.Len(t, prompts, 2, "both prompts should match 'database'")
+	assert.Equal(t, nameMatch.ID, prompts[0].ID, "name match (weight A) should rank first")
+	assert.Equal(t, descMatch.ID, prompts[1].ID, "description match (weight B) should rank second")
+}
+
+func TestListPrompts_FTS_RespectsStatusFilter(t *testing.T) {
+	// An archived prompt must not appear in active-only FTS results,
+	// even if its tsvector would match the query.
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	active, err := store.CreatePrompt(ctx, tm.ID, "active", "Database Active", "desc")
+	require.NoError(t, err)
+
+	archived, err := store.CreatePrompt(ctx, tm.ID, "archived", "Database Archived", "desc")
+	require.NoError(t, err)
+
+	require.NoError(t, store.ArchivePrompt(ctx, archived.ID, []uuid.UUID{tm.ID}))
+
+	activeStatus := model.PromptStatusActive
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
+		TeamIDs: []uuid.UUID{tm.ID},
+		Q:       "database",
+		Status:  &activeStatus,
+	})
+	require.NoError(t, err)
+	require.Len(t, prompts, 1)
+	assert.Equal(t, active.ID, prompts[0].ID)
+}
+
+func TestListPrompts_FTS_TeamScope(t *testing.T) {
+	// A match in another team must not bleed into the caller's results.
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tmA, err := store.CreateTeam(ctx, "Team A")
+	require.NoError(t, err)
+	tmB, err := store.CreateTeam(ctx, "Team B")
+	require.NoError(t, err)
+
+	_, err = store.CreatePrompt(ctx, tmA.ID, "a", "Database in A", "desc")
+	require.NoError(t, err)
+	promptB, err := store.CreatePrompt(ctx, tmB.ID, "b", "Database in B", "desc")
+	require.NoError(t, err)
+
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
+		TeamIDs: []uuid.UUID{tmB.ID},
+		Q:       "database",
+	})
+	require.NoError(t, err)
+	require.Len(t, prompts, 1)
+	assert.Equal(t, promptB.ID, prompts[0].ID)
+}
+
+func TestListPrompts_FTS_NoMatch(t *testing.T) {
+	// A query with no real lexical overlap should return empty,
+	// not every prompt that contains the substring anywhere.
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	_, err = store.CreatePrompt(ctx, tm.ID, "p1", "Refund Helper", "handles refunds")
+	require.NoError(t, err)
+	_, err = store.CreatePrompt(ctx, tm.ID, "p2", "Shipping Tracker", "tracks parcels")
+	require.NoError(t, err)
+
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
+		TeamIDs: []uuid.UUID{tm.ID},
+		Q:       "quantum physics",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, prompts, "out-of-domain query should not match anything")
+}
+
+func TestListPrompts_FTS_Limit(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, err := store.CreatePrompt(ctx, tm.ID,
+			fmt.Sprintf("p%d", i), fmt.Sprintf("Database %d", i), "desc")
+		require.NoError(t, err)
+	}
+
+	limit := 2
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
+		TeamIDs: []uuid.UUID{tm.ID},
+		Q:       "database",
+		Limit:   &limit,
+	})
+	require.NoError(t, err)
+	assert.Len(t, prompts, 2)
 }
 
 func TestGetPromptByID(t *testing.T) {
@@ -155,7 +294,7 @@ func TestArchivePrompt_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
 
-func TestListPrompts_Filters(t *testing.T) {
+func TestListPromptsByFilter_Filters(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 	tm, err := store.CreateTeam(ctx, "Test Team")
@@ -172,7 +311,7 @@ func TestListPrompts_Filters(t *testing.T) {
 
 	// Test Archived = false (Active only)
 	activeOnly := false
-	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
+	prompts, err := store.ListPromptsByFilter(ctx, store.PromptFilter{
 		TeamIDs:  []uuid.UUID{tm.ID},
 		Archived: &activeOnly,
 	})
@@ -182,7 +321,7 @@ func TestListPrompts_Filters(t *testing.T) {
 
 	// Test Archived = true (Archived only)
 	archivedOnly := true
-	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
+	prompts, err = store.ListPromptsByFilter(ctx, store.PromptFilter{
 		TeamIDs:  []uuid.UUID{tm.ID},
 		Archived: &archivedOnly,
 	})
@@ -197,7 +336,7 @@ func TestListPrompts_Filters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Filter by tag "prod"
-	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
+	prompts, err = store.ListPromptsByFilter(ctx, store.PromptFilter{
 		TeamIDs: []uuid.UUID{tm.ID},
 		Tags:    []string{"prod"},
 	})
@@ -206,7 +345,7 @@ func TestListPrompts_Filters(t *testing.T) {
 	assert.Equal(t, pA.ID, prompts[0].ID)
 
 	// Filter by non-existent tag
-	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
+	prompts, err = store.ListPromptsByFilter(ctx, store.PromptFilter{
 		TeamIDs: []uuid.UUID{tm.ID},
 		Tags:    []string{"nonexistent_tag"},
 	})
@@ -215,7 +354,7 @@ func TestListPrompts_Filters(t *testing.T) {
 
 	// Filter by Status = "active"
 	activeStatus := model.PromptStatusActive
-	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
+	prompts, err = store.ListPromptsByFilter(ctx, store.PromptFilter{
 		TeamIDs: []uuid.UUID{tm.ID},
 		Status:  &activeStatus,
 	})
@@ -225,7 +364,7 @@ func TestListPrompts_Filters(t *testing.T) {
 
 	// Filter by Status = "archived"
 	archivedStatus := model.PromptStatusArchived
-	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
+	prompts, err = store.ListPromptsByFilter(ctx, store.PromptFilter{
 		TeamIDs: []uuid.UUID{tm.ID},
 		Status:  &archivedStatus,
 	})

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -65,9 +65,44 @@ func GetSessionByToken(ctx context.Context, token string) (*model.Session, error
 // DeleteSession removes the session from Postgres and evicts it from the cache
 // so a logged-out token cannot be replayed via a stale cache entry.
 func DeleteSession(ctx context.Context, token string) error {
-	evictSession(ctx, token)
 	_, err := db.Pool.Exec(ctx, "DELETE FROM sessions WHERE token = $1", token)
-	return err
+	if err != nil {
+		return err
+	}
+	evictSession(ctx, token)
+	return nil
+}
+
+// DeleteSessionsByUserID removes all sessions for a user from Postgres and evicts them from the cache.
+func DeleteSessionsByUserID(ctx context.Context, userID uuid.UUID) error {
+	rows, err := db.Pool.Query(ctx, "SELECT token FROM sessions WHERE user_id = $1", userID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var tokens []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return err
+		}
+		tokens = append(tokens, t)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = db.Pool.Exec(ctx, "DELETE FROM sessions WHERE user_id = $1", userID)
+	if err != nil {
+		return err
+	}
+
+	for _, t := range tokens {
+		evictSession(ctx, t)
+	}
+
+	return nil
 }
 
 // sessionFromCache returns a session from Redis or nil on any miss/error.

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -159,7 +159,7 @@ func GetPasswordResetByCode(ctx context.Context, code string) (uuid.UUID, time.T
 	var userID uuid.UUID
 	var expiresAt time.Time
 	err := db.Pool.QueryRow(ctx,
-		`SELECT user_id, expires_at FROM password_resets WHERE code = $1`,
+		`SELECT user_id, expires_at FROM password_resets WHERE code = $1 AND expires_at > NOW()`,
 		code,
 	).Scan(&userID, &expiresAt)
 	if err != nil {
@@ -179,6 +179,11 @@ func UpdateUserPassword(ctx context.Context, userID uuid.UUID, passwordHash stri
 	if err != nil {
 		return fmt.Errorf("update user password: %w", err)
 	}
+	
+	if err := DeleteSessionsByUserID(ctx, userID); err != nil {
+		return fmt.Errorf("delete user sessions: %w", err)
+	}
+
 	return nil
 }
 
@@ -220,6 +225,10 @@ func UpdateUserEmail(ctx context.Context, id uuid.UUID, email string) error {
 }
 
 func DeleteUser(ctx context.Context, id uuid.UUID) error {
+	if err := DeleteSessionsByUserID(ctx, id); err != nil {
+		return fmt.Errorf("delete user sessions: %w", err)
+	}
+
 	_, err := db.Pool.Exec(ctx,
 		`DELETE FROM users WHERE id = $1`,
 		id,


### PR DESCRIPTION
# PR Title: Add configurable search layer with PostgreSQL FTS for Prompts

Fixes #9

## What
- Add a configurable abstracted search layer (`internal/search` and `internal/searchfactory`) for prompts.
- Implement PostgreSQL Full-Text Search (FTS) as the default search provider.
- Update `GET /v1/teams/{teamID}/prompts` endpoint to support a `q` search parameter.
- Ensure archived prompts are correctly hidden from search results.
- Add a `noop` search provider fallback and configuration logic.
- Add comprehensive prompt deletion logic (`DELETE /v1/prompts/:id`).

## Why
As requested in #9, users need a way to search for prompts by name or description. A configurable search layer allows future support for Elasticsearch, Algolia, etc., while PostgreSQL FTS serves as an excellent, zero-dependency default. The implementation securely handles search string parsing, natively supports stemming, and excludes archived items to prevent search result clutter.

## How
- Created `internal/search/provider.go` defining the `SearchProvider` interface, along with `internal/search/errors.go` and `global.go` for shared search logic.
- Added `internal/search/postgres/provider.go` implementing the postgres provider using `to_tsvector` and `to_tsquery` (via migration `020_prompts_fts.sql`).
- Added a fallback `noop` search provider (`internal/search/noop.go`).
- Wired up the search provider via `internal/searchfactory/factory.go` and added environment configuration in `.env.example`.
- Initialized the search factory in `cmd/server/main.go` and injected it into the application state in `internal/app/app.go`.
- Updated `internal/handler/prompt.go` to check for the `q` parameter. If present, it uses the search provider to resolve IDs and then fetches the payloads via the newly added `store.GetPromptsByIDs`.
- Added prompt deletion handler and store logic.
- Documented the new `q` query parameter and `DELETE` operation in `docs/openapi/prompts.yaml` and re-generated the OpenAPI bundle.

## Testing
- Run `make test` — passes (all unit and integration tests)
- Run `make spec-bundle` — cleanly builds the OpenAPI bundle without drift

### Manual Verification
Ran the full E2E test suite script for Issue #9 against the local instance, which verified search indexing, archiving exclusion, native Postgres stemming, and SQL injection safety.

<details>
<summary><b>Click to view reproduction script</b></summary>

```powershell
$base = "http://localhost:3000"
$team = "<YOUR_TEAM_ID>"
$h = @{ Authorization = "Bearer <YOUR_TOKEN>" }

# 1. Create a prompt
$createBody = "{`"name`": `"billing query`", `"slug`": `"bill_q`", `"description`": `"Handles billing queries`", `"status`": `"active`"}"
$create = Invoke-RestMethod -Method Post -Uri "$base/v1/teams/$team/prompts" -Headers $h -Body $createBody 
$promptId = $create.prompt.id

# 2. Search for 'billing' (Should exist)
$search1 = Invoke-RestMethod -Method Get -Uri "$base/v1/teams/$team/prompts?q=billing" -Headers $h

# 3. Update description
$updateBody = "{`"description`": `"Handles technical issues`", `"status`": `"active`"}"
Invoke-RestMethod -Method Put -Uri "$base/v1/prompts/$promptId" -Headers $h -Body $updateBody    

# 4. Search for 'technical' (Should exist)
$search2 = Invoke-RestMethod -Method Get -Uri "$base/v1/teams/$team/prompts?q=technical" -Headers $h

# 5. Archive Prompt (Should hide from search)
Invoke-RestMethod -Method Post -Uri "$base/v1/prompts/$promptId/archive" -Headers $h
$search3 = Invoke-RestMethod -Method Get -Uri "$base/v1/teams/$team/prompts?q=technical" -Headers $h

# 6. Test Edge Cases (Empty, Malicious, Stemming)
$emptySearch = Invoke-RestMethod -Method Get -Uri "$base/v1/teams/$team/prompts?q=" -Headers $h
$maliciousSearch = Invoke-RestMethod -Method Get -Uri "$base/v1/teams/$team/prompts?q=test'; DROP TABLE prompts;--" -Headers $h

# Cleanup
Invoke-RestMethod -Method Delete -Uri "$base/v1/prompts/$promptId" -Headers $h
```
</details>
