### PR TITLE
Move prompts under a Project entity

### DIFF
--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -1717,7 +1717,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
-  /v1/projects/{id}:
+  /v1/projects/{projectID}:
     get:
       summary: Get a Project
       description: |
@@ -1730,7 +1730,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.
@@ -1786,7 +1786,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.
@@ -1833,7 +1833,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
-  /v1/projects/{id}/access:
+  /v1/projects/{projectID}/access:
     post:
       summary: Grant Project Access
       description: |
@@ -1847,7 +1847,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.
@@ -1910,7 +1910,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
-  /v1/projects/{id}/access/{teamID}:
+  /v1/projects/{projectID}/access/{teamID}:
     delete:
       summary: Revoke Project Access
       description: |
@@ -1923,7 +1923,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.
@@ -2034,26 +2034,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
-  /v1/teams/{teamID}/prompts:
+  /v1/projects/{projectID}/prompts:
     post:
       summary: Create a Prompt
-      description: Creates a new prompt container.
+      description: Creates a new prompt inside a project. The requester must be an editor-or-above on the project (via the owning team or a granted team).
       operationId: createPrompt
       tags:
         - Prompts
       security:
         - BearerAuth: []
       parameters:
-        - name: teamID
+        - name: projectID
           in: path
           required: true
           schema:
             type: string
             format: uuid
-          description: The ID of the team.
+          description: The ID of the project.
+      x-edge-cases:
+        - A viewer of the project is refused with 403; an unknown project returns 404.
+        - Slug uniqueness is scoped to the project, so the same slug may exist in another project.
       x-test-coverage:
         - 'TestCreatePrompt_Success: Verifies prompt creation and response payload.'
         - 'TestCreatePrompt_MissingName: Verifies that missing name returns 400 and ''name is required''.'
+        - 'TestCreatePrompt_ForbiddenForViewer: Verifies a viewer cannot create a prompt (403).'
+        - 'TestCreatePrompt_UnknownProject: Verifies an unknown project returns 404.'
         - 'TestCreatePrompt_Unauthorized: Verifies that unauthenticated request returns 401.'
       requestBody:
         required: true
@@ -2094,6 +2099,24 @@ paths:
                 $ref: '#/components/schemas/APIError'
               example:
                 error: unauthorized
+        '403':
+          description: Forbidden (requester is not an editor of the project)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '409':
+          description: A prompt with this name or slug already exists in the project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '500':
           description: Internal Server Error
           content:
@@ -2104,20 +2127,20 @@ paths:
                 error: internal error
     get:
       summary: List Prompts
-      description: Lists all available prompt containers.
+      description: Lists the prompts inside a project. The requester must be able to reach the project.
       operationId: listPrompts
       tags:
         - Prompts
       security:
         - BearerAuth: []
       parameters:
-        - name: teamID
+        - name: projectID
           in: path
           required: true
           schema:
             type: string
             format: uuid
-          description: The ID of the team.
+          description: The ID of the project.
         - name: archived
           in: query
           required: false
@@ -2149,6 +2172,18 @@ paths:
                 $ref: '#/components/schemas/APIError'
               example:
                 error: unauthorized
+        '403':
+          description: Forbidden (requester cannot reach the project)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
         '500':
           description: Internal Server Error
           content:
@@ -2159,25 +2194,25 @@ paths:
                 error: internal error
   /v1/prompts:
     get:
-      summary: List all prompts with team filter
-      description: Returns a list of prompts. If team_id query parameter is not provided, returns an empty list by default. Users can filter by a team they are a member of.
+      summary: List all prompts with project filter
+      description: Returns a list of prompts. If the project_id query parameter is not provided, returns an empty list by default. Users can filter by a project they can reach.
       operationId: listAllPrompts
       tags:
         - Prompts
       security:
         - BearerAuth: []
       parameters:
-        - name: team_id
+        - name: project_id
           in: query
           required: false
-          description: Optional UUID of the team to filter prompts (alias of team).
+          description: Optional UUID of the project to filter prompts (alias of project).
           schema:
             type: string
             format: uuid
-        - name: team
+        - name: project
           in: query
           required: false
-          description: Optional UUID of the team to filter prompts (alias of team_id).
+          description: Optional UUID of the project to filter prompts (alias of project_id).
           schema:
             type: string
             format: uuid
@@ -2188,12 +2223,12 @@ paths:
           schema:
             type: boolean
       x-edge-cases:
-        - By default with no team_id query parameter, returns an empty list of prompts.
-        - If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden.
+        - By default with no project_id query parameter, returns an empty list of prompts.
+        - If a project_id is provided, checks the requester can reach that project, otherwise returns 403 Forbidden.
       x-test-coverage:
-        - 'TestListAllPrompts: Verifies that no team_id returns 200 with an empty list.'
-        - 'TestListAllPrompts: Verifies that a valid team_id returns 200 with prompts of that team.'
-        - 'TestListAllPrompts: Verifies that an unallowed team_id returns 403 Forbidden.'
+        - 'TestListAllPrompts: Verifies that no project_id returns 200 with an empty list.'
+        - 'TestListAllPrompts: Verifies that a valid project_id returns 200 with prompts of that project.'
+        - 'TestListAllPrompts: Verifies that an unallowed project_id returns 403 Forbidden.'
       responses:
         '200':
           description: A list of prompts
@@ -2512,7 +2547,7 @@ paths:
   /v1/prompts/{id}/move:
     post:
       summary: Move a Prompt
-      description: Moves a prompt from its current team to another team. Requires admin privileges on both teams.
+      description: Moves a prompt from its current project to another project. Requires admin capability on both the source and target project (owning-team or org admin).
       operationId: movePrompt
       tags:
         - Prompts
@@ -2525,6 +2560,13 @@ paths:
           schema:
             type: string
             format: uuid
+      x-edge-cases:
+        - Requires admin on both source and target project; a non-admin on either side is refused with 403.
+        - A move into a project where the prompt's name or slug already exists is rejected with 409.
+        - An unknown prompt or an unknown target project returns 404.
+      x-test-coverage:
+        - 'TestMovePrompt: Verifies an admin moves a prompt between projects (200).'
+        - 'TestMovePrompt_TargetCollision: Verifies a name/slug collision in the target project returns 409.'
       requestBody:
         required: true
         content:
@@ -2532,11 +2574,12 @@ paths:
             schema:
               type: object
               required:
-                - team_id
+                - project_id
               properties:
-                team_id:
+                project_id:
                   type: string
                   format: uuid
+                  description: The target project to move the prompt into.
       responses:
         '200':
           description: Prompt successfully moved
@@ -2550,7 +2593,7 @@ paths:
                 required:
                   - prompt
         '400':
-          description: Invalid UUID format or team_id
+          description: Invalid UUID format or project_id
           content:
             application/json:
               schema:
@@ -2562,13 +2605,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIError'
         '403':
-          description: Forbidden
+          description: Forbidden (not an admin on the source or target project)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
         '404':
-          description: Prompt not found
+          description: Prompt or target project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '409':
+          description: A prompt with this name or slug already exists in the target project
           content:
             application/json:
               schema:
@@ -2656,20 +2705,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
-  /v1/prompts/{slug}/render:
+  /v1/projects/{projectID}/prompts/{slug}/render:
     post:
       summary: Render Live Prompt Version
-      description: Renders the active 'live' template version of a prompt using supplied variables.
+      description: Renders the active 'live' template version of a prompt using supplied variables. The prompt is resolved by slug within the given project, so the same slug may be reused across projects.
       operationId: renderLive
       tags:
         - Prompt Renders
       security:
         - BearerAuth: []
       parameters:
+        - name: projectID
+          in: path
+          required: true
+          description: The ID of the project the prompt belongs to.
+          schema:
+            type: string
+            format: uuid
         - name: slug
           in: path
           required: true
-          description: Unique prompt slug.
+          description: Prompt slug, unique within the project.
           schema:
             type: string
       x-edge-cases:
@@ -3383,20 +3439,27 @@ paths:
                 $ref: '#/components/schemas/APIError'
               example:
                 error: version not found
-  /v1/prompts/{slug}/versions/{version}/render:
+  /v1/projects/{projectID}/prompts/{slug}/versions/{version}/render:
     post:
       summary: Render Specific Prompt Version
-      description: Renders a specific template version of a prompt (even draft status) using supplied variables.
+      description: Renders a specific template version of a prompt (even draft status) using supplied variables. The prompt is resolved by slug within the given project.
       operationId: renderVersion
       tags:
         - Prompt Renders
       security:
         - BearerAuth: []
       parameters:
+        - name: projectID
+          in: path
+          required: true
+          description: The ID of the project the prompt belongs to.
+          schema:
+            type: string
+            format: uuid
         - name: slug
           in: path
           required: true
-          description: Unique prompt slug.
+          description: Prompt slug, unique within the project.
           schema:
             type: string
         - name: version
@@ -4104,13 +4167,13 @@ components:
           type: string
           format: uuid
           description: Unique identifier.
-        team_id:
+        project_id:
           type: string
           format: uuid
-          description: Unique identifier of the team.
+          description: Unique identifier of the project the prompt belongs to.
         slug:
           type: string
-          description: Unique slug within the team.
+          description: Unique slug within the project.
         name:
           type: string
           description: Name of the prompt container.
@@ -4131,7 +4194,7 @@ components:
           format: date-time
       required:
         - id
-        - team_id
+        - project_id
         - slug
         - name
         - description

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -2147,9 +2147,14 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+      x-edge-cases:
+        - An API key reaches the prompts of every project its teams can access — owned or granted — and loses that reach when the grant is revoked.
       x-test-coverage:
         - 'TestListPrompts: Verifies listing populated prompt containers.'
         - 'TestListPrompts_Empty: Verifies that listing when empty returns an empty array.'
+        - 'TestPrompts_APIKeyAuth: Verifies an API key lists a project owned by its team.'
+        - 'TestAPIKey_ReachesGrantedProject: Verifies an API key reaches a granted project''s prompts and is denied after revoke.'
+        - 'TestAPIKey_DeniedForeignProject: Verifies an API key is denied a project its teams cannot access.'
       responses:
         '200':
           description: List of prompts

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -1833,6 +1833,151 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
+  /v1/projects/{id}/access:
+    post:
+      summary: Grant Project Access
+      description: |
+        Grants another team access to the project's prompts. The requester must
+        be an admin of the owning team or an admin of its organization. The
+        grantee team must belong to the same organization as the owning team.
+        An org-less owning team cannot share its projects.
+      operationId: grantProjectAccess
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - A non-admin of the owning team is refused with 403.
+        - A grantee team in a different organization is refused with 403.
+        - An org-less owning team cannot share; the grant is refused with 403.
+        - Granting to the owning team is rejected with 400 (it already has implicit access).
+        - Re-granting an existing access is idempotent and returns 201.
+        - An unknown project returns 404; an unknown grantee team returns 404.
+      x-test-coverage:
+        - 'TestGrantProjectAccess_Success: owning-team admin grants same-org team (201) and the grantee reaches the project.'
+        - 'TestGrantProjectAccess_ForbiddenForNonAdmin: an editor is refused (403).'
+        - 'TestGrantProjectAccess_RejectsTeamOutsideOrg: a foreign-org grantee is refused (403).'
+        - 'TestGrantProjectAccess_RejectsOrgLessOwner: an org-less owning team cannot share (403).'
+        - 'TestGrantProjectAccess_UnknownProject: an unknown project returns 404.'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrantProjectAccessRequest'
+      responses:
+        '201':
+          description: Access granted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectAccessResponse'
+        '400':
+          description: Invalid request (invalid body/team_id, or grantee is the owning team)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Forbidden (non-admin, org-less owner, or grantee outside org)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Project or grantee team not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /v1/projects/{id}/access/{teamID}:
+    delete:
+      summary: Revoke Project Access
+      description: |
+        Revokes a team's access to the project. The requester must be an admin
+        of the owning team or an admin of its organization. The owning team's
+        implicit access cannot be revoked through this endpoint.
+      operationId: revokeProjectAccess
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+        - name: teamID
+          in: path
+          required: true
+          description: The ID of the team whose access is being revoked.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - A non-admin of the owning team is refused with 403.
+        - Revoking an access that does not exist returns 404.
+        - An unknown project returns 404.
+      x-test-coverage:
+        - 'TestRevokeProjectAccess_Success: an admin revokes access (204) and the grantee loses reachability.'
+        - 'TestRevokeProjectAccess_ForbiddenForNonAdmin: an editor is refused (403).'
+        - 'TestRevokeProjectAccess_NotFound: revoking a non-existent grant returns 404.'
+      responses:
+        '204':
+          description: Access revoked successfully (No Content)
+        '400':
+          description: Invalid project or team id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Forbidden (requester is not an admin of the owning team or org)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Project or access grant not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /v1/teams/{teamID}/projects:
     get:
       summary: List a Team's Projects
@@ -4380,6 +4525,34 @@ components:
       properties:
         project:
           $ref: '#/components/schemas/Project'
+    GrantProjectAccessRequest:
+      type: object
+      required:
+        - team_id
+      properties:
+        team_id:
+          type: string
+          format: uuid
+          description: The team to grant access to. Must be in the owning team's organization.
+    ProjectAccess:
+      type: object
+      required:
+        - project_id
+        - team_id
+      properties:
+        project_id:
+          type: string
+          format: uuid
+        team_id:
+          type: string
+          format: uuid
+    ProjectAccessResponse:
+      type: object
+      required:
+        - access
+      properties:
+        access:
+          $ref: '#/components/schemas/ProjectAccess'
     ProjectListResponse:
       type: object
       required:

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -1644,6 +1644,251 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIError'
+  /v1/projects:
+    post:
+      summary: Create a Project
+      description: |
+        Creates a project owned by a team. The requester must be an
+        editor-or-above member of the owning team, or an admin of that team's
+        organization. The project name and slug must each be unique within the
+        owning team.
+      operationId: createProject
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      x-edge-cases:
+        - A viewer of the owning team, or a non-member, is refused with 403.
+        - An org admin can create a project for any team in their org without being a member of that team.
+        - A duplicate name or slug within the same owning team returns 409; the same name/slug under a different team is allowed.
+        - If slug is omitted it is derived from the name and normalized.
+      x-test-coverage:
+        - 'TestCreateProject_Success: editor creates a project (201).'
+        - 'TestCreateProject_ForbiddenForViewer: a viewer is refused (403).'
+        - 'TestCreateProject_MissingName: missing name returns 400.'
+        - 'TestCreateProject_Duplicate: duplicate name/slug in the same team returns 409.'
+        - 'TestCreateProject_Unauthorized: unauthenticated request returns 401.'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateProjectRequest'
+      responses:
+        '201':
+          description: Project created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        '400':
+          description: Invalid request (invalid body, invalid team_id, or missing name)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Forbidden (requester is not an editor of the team or an org admin)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Owning team not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '409':
+          description: A project with this name or slug already exists in the team
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /v1/projects/{id}:
+    get:
+      summary: Get a Project
+      description: |
+        Fetches a project by ID. The requester must be able to reach the
+        project — as a member of the owning team or of a team granted access.
+        Projects the requester cannot reach are reported as not found.
+      operationId: getProject
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - An unknown project id, or one the requester cannot reach, returns 404.
+      x-test-coverage:
+        - 'TestGetProject_Success: owning-team member fetches the project (200).'
+        - 'TestGetProject_NotFoundForNonMember: a non-member gets 404.'
+        - 'TestGetProject_NotFound: an unknown id returns 404.'
+      responses:
+        '200':
+          description: The project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        '400':
+          description: Invalid project id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Project not found or not reachable by the requester
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+    delete:
+      summary: Delete a Project
+      description: |
+        Hard-deletes a project, cascading to its prompts (and their versions,
+        tags, and payloads) and dropping its access grants. The requester must
+        be an admin of the owning team or an admin of that team's organization.
+      operationId: deleteProject
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - A non-admin member of the owning team is refused with 403.
+        - An unknown project id returns 404.
+      x-test-coverage:
+        - 'TestDeleteProject_Success: an owning-team admin deletes the project (204).'
+        - 'TestDeleteProject_ForbiddenForNonAdmin: a non-admin is refused (403).'
+        - 'TestDeleteProject_NotFound: an unknown id returns 404.'
+      responses:
+        '204':
+          description: Project deleted successfully (No Content)
+        '400':
+          description: Invalid project id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Forbidden (requester is not an admin of the owning team or org)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+  /v1/teams/{teamID}/projects:
+    get:
+      summary: List a Team's Projects
+      description: |
+        Lists the projects a team owns plus those granted to it. The requester
+        must be a member of the team.
+      operationId: listTeamProjects
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: teamID
+          in: path
+          required: true
+          description: The ID of the team.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - A non-member of the team is refused with 403.
+        - A team owning and granted nothing returns an empty array.
+      x-test-coverage:
+        - 'TestListTeamProjects_Success: a member lists the team''s owned projects (200).'
+        - 'TestListTeamProjects_ForbiddenForNonMember: a non-member gets 403.'
+      responses:
+        '200':
+          description: List of projects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectListResponse'
+        '400':
+          description: Invalid team id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '403':
+          description: Forbidden (requester is not a member of the team)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
   /v1/teams/{teamID}/prompts:
     post:
       summary: Create a Prompt
@@ -4087,6 +4332,63 @@ components:
         created_at:
           type: string
           format: date-time
+    CreateProjectRequest:
+      type: object
+      required:
+        - team_id
+        - name
+      properties:
+        team_id:
+          type: string
+          format: uuid
+          description: The team that will own the project.
+        name:
+          type: string
+          description: Human-readable project name.
+        slug:
+          type: string
+          description: Optional normalized slug; derived from the name when omitted.
+    Project:
+      type: object
+      required:
+        - id
+        - owning_team_id
+        - name
+        - slug
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        owning_team_id:
+          type: string
+          format: uuid
+          description: The team that owns the project.
+        name:
+          type: string
+          description: Human-readable project name, unique within the owning team.
+        slug:
+          type: string
+          description: Normalized identifier, unique within the owning team.
+        created_at:
+          type: string
+          format: date-time
+    ProjectResponse:
+      type: object
+      required:
+        - project
+      properties:
+        project:
+          $ref: '#/components/schemas/Project'
+    ProjectListResponse:
+      type: object
+      required:
+        - projects
+      properties:
+        projects:
+          type: array
+          items:
+            $ref: '#/components/schemas/Project'
     CreatePromptRequest:
       type: object
       properties:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -60,6 +60,12 @@ paths:
     $ref: "./orgs.yaml#/paths/~1v1~1orgs~1{orgID}~1people"
   /v1/orgs/{orgID}/members/{userID}:
     $ref: "./orgs.yaml#/paths/~1v1~1orgs~1{orgID}~1members~1{userID}"
+  /v1/projects:
+    $ref: "./projects.yaml#/paths/~1v1~1projects"
+  /v1/projects/{id}:
+    $ref: "./projects.yaml#/paths/~1v1~1projects~1{id}"
+  /v1/teams/{teamID}/projects:
+    $ref: "./projects.yaml#/paths/~1v1~1teams~1{teamID}~1projects"
   /v1/teams/{teamID}/prompts:
     $ref: "./prompts.yaml#/paths/~1v1~1teams~1{teamID}~1prompts"
   /v1/prompts:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -64,6 +64,10 @@ paths:
     $ref: "./projects.yaml#/paths/~1v1~1projects"
   /v1/projects/{id}:
     $ref: "./projects.yaml#/paths/~1v1~1projects~1{id}"
+  /v1/projects/{id}/access:
+    $ref: "./projects.yaml#/paths/~1v1~1projects~1{id}~1access"
+  /v1/projects/{id}/access/{teamID}:
+    $ref: "./projects.yaml#/paths/~1v1~1projects~1{id}~1access~1{teamID}"
   /v1/teams/{teamID}/projects:
     $ref: "./projects.yaml#/paths/~1v1~1teams~1{teamID}~1projects"
   /v1/teams/{teamID}/prompts:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -62,16 +62,16 @@ paths:
     $ref: "./orgs.yaml#/paths/~1v1~1orgs~1{orgID}~1members~1{userID}"
   /v1/projects:
     $ref: "./projects.yaml#/paths/~1v1~1projects"
-  /v1/projects/{id}:
-    $ref: "./projects.yaml#/paths/~1v1~1projects~1{id}"
-  /v1/projects/{id}/access:
-    $ref: "./projects.yaml#/paths/~1v1~1projects~1{id}~1access"
-  /v1/projects/{id}/access/{teamID}:
-    $ref: "./projects.yaml#/paths/~1v1~1projects~1{id}~1access~1{teamID}"
+  /v1/projects/{projectID}:
+    $ref: "./projects.yaml#/paths/~1v1~1projects~1{projectID}"
+  /v1/projects/{projectID}/access:
+    $ref: "./projects.yaml#/paths/~1v1~1projects~1{projectID}~1access"
+  /v1/projects/{projectID}/access/{teamID}:
+    $ref: "./projects.yaml#/paths/~1v1~1projects~1{projectID}~1access~1{teamID}"
   /v1/teams/{teamID}/projects:
     $ref: "./projects.yaml#/paths/~1v1~1teams~1{teamID}~1projects"
-  /v1/teams/{teamID}/prompts:
-    $ref: "./prompts.yaml#/paths/~1v1~1teams~1{teamID}~1prompts"
+  /v1/projects/{projectID}/prompts:
+    $ref: "./prompts.yaml#/paths/~1v1~1projects~1{projectID}~1prompts"
   /v1/prompts:
     $ref: "./prompts.yaml#/paths/~1v1~1prompts"
   /v1/prompts/{id}:
@@ -84,8 +84,8 @@ paths:
     $ref: "./prompts.yaml#/paths/~1v1~1prompts~1{id}~1move"
   /v1/prompts/{id}/versions/diff:
     $ref: "./prompt-versions.yaml#/paths/~1v1~1prompts~1{id}~1versions~1diff"
-  /v1/prompts/{slug}/render:
-    $ref: "./prompt-renders.yaml#/paths/~1v1~1prompts~1{slug}~1render"
+  /v1/projects/{projectID}/prompts/{slug}/render:
+    $ref: "./prompt-renders.yaml#/paths/~1v1~1projects~1{projectID}~1prompts~1{slug}~1render"
   /v1/prompts/{id}/versions:
     $ref: "./prompt-versions.yaml#/paths/~1v1~1prompts~1{id}~1versions"
   /v1/prompts/{id}/versions/{version}:
@@ -98,8 +98,8 @@ paths:
     $ref: "./prompt-versions.yaml#/paths/~1v1~1prompts~1{id}~1versions~1{version}~1archive"
   /v1/prompts/{id}/versions/{version}/duplicate:
     $ref: "./prompt-versions.yaml#/paths/~1v1~1prompts~1{id}~1versions~1{version}~1duplicate"
-  /v1/prompts/{slug}/versions/{version}/render:
-    $ref: "./prompt-renders.yaml#/paths/~1v1~1prompts~1{slug}~1versions~1{version}~1render"
+  /v1/projects/{projectID}/prompts/{slug}/versions/{version}/render:
+    $ref: "./prompt-renders.yaml#/paths/~1v1~1projects~1{projectID}~1prompts~1{slug}~1versions~1{version}~1render"
   /v1/prompts/{id}/versions/{version}/tags:
     $ref: "./prompt-versions.yaml#/paths/~1v1~1prompts~1{id}~1versions~1{version}~1tags"
   /v1/prompts/{id}/tags:

--- a/docs/openapi/projects.yaml
+++ b/docs/openapi/projects.yaml
@@ -194,6 +194,153 @@ paths:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
 
+  /v1/projects/{id}/access:
+    post:
+      summary: Grant Project Access
+      description: |
+        Grants another team access to the project's prompts. The requester must
+        be an admin of the owning team or an admin of its organization. The
+        grantee team must belong to the same organization as the owning team.
+        An org-less owning team cannot share its projects.
+      operationId: grantProjectAccess
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - "A non-admin of the owning team is refused with 403."
+        - "A grantee team in a different organization is refused with 403."
+        - "An org-less owning team cannot share; the grant is refused with 403."
+        - "Granting to the owning team is rejected with 400 (it already has implicit access)."
+        - "Re-granting an existing access is idempotent and returns 201."
+        - "An unknown project returns 404; an unknown grantee team returns 404."
+      x-test-coverage:
+        - "TestGrantProjectAccess_Success: owning-team admin grants same-org team (201) and the grantee reaches the project."
+        - "TestGrantProjectAccess_ForbiddenForNonAdmin: an editor is refused (403)."
+        - "TestGrantProjectAccess_RejectsTeamOutsideOrg: a foreign-org grantee is refused (403)."
+        - "TestGrantProjectAccess_RejectsOrgLessOwner: an org-less owning team cannot share (403)."
+        - "TestGrantProjectAccess_UnknownProject: an unknown project returns 404."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GrantProjectAccessRequest"
+      responses:
+        "201":
+          description: Access granted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectAccessResponse"
+        "400":
+          description: Invalid request (invalid body/team_id, or grantee is the owning team)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "403":
+          description: Forbidden (non-admin, org-less owner, or grantee outside org)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Project or grantee team not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+
+  /v1/projects/{id}/access/{teamID}:
+    delete:
+      summary: Revoke Project Access
+      description: |
+        Revokes a team's access to the project. The requester must be an admin
+        of the owning team or an admin of its organization. The owning team's
+        implicit access cannot be revoked through this endpoint.
+      operationId: revokeProjectAccess
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+        - name: teamID
+          in: path
+          required: true
+          description: The ID of the team whose access is being revoked.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - "A non-admin of the owning team is refused with 403."
+        - "Revoking an access that does not exist returns 404."
+        - "An unknown project returns 404."
+      x-test-coverage:
+        - "TestRevokeProjectAccess_Success: an admin revokes access (204) and the grantee loses reachability."
+        - "TestRevokeProjectAccess_ForbiddenForNonAdmin: an editor is refused (403)."
+        - "TestRevokeProjectAccess_NotFound: revoking a non-existent grant returns 404."
+      responses:
+        "204":
+          description: Access revoked successfully (No Content)
+        "400":
+          description: Invalid project or team id
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "403":
+          description: Forbidden (requester is not an admin of the owning team or org)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Project or access grant not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+
   /v1/teams/{teamID}/projects:
     get:
       summary: List a Team's Projects
@@ -294,6 +441,34 @@ components:
         slug:
           type: string
           description: Optional normalized slug; derived from the name when omitted.
+    GrantProjectAccessRequest:
+      type: object
+      required:
+        - team_id
+      properties:
+        team_id:
+          type: string
+          format: uuid
+          description: The team to grant access to. Must be in the owning team's organization.
+    ProjectAccess:
+      type: object
+      required:
+        - project_id
+        - team_id
+      properties:
+        project_id:
+          type: string
+          format: uuid
+        team_id:
+          type: string
+          format: uuid
+    ProjectAccessResponse:
+      type: object
+      required:
+        - access
+      properties:
+        access:
+          $ref: "#/components/schemas/ProjectAccess"
     ProjectResponse:
       type: object
       required:

--- a/docs/openapi/projects.yaml
+++ b/docs/openapi/projects.yaml
@@ -1,0 +1,312 @@
+openapi: 3.1.0
+info:
+  title: Projects API
+  version: 1.0.0
+paths:
+  /v1/projects:
+    post:
+      summary: Create a Project
+      description: |
+        Creates a project owned by a team. The requester must be an
+        editor-or-above member of the owning team, or an admin of that team's
+        organization. The project name and slug must each be unique within the
+        owning team.
+      operationId: createProject
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      x-edge-cases:
+        - "A viewer of the owning team, or a non-member, is refused with 403."
+        - "An org admin can create a project for any team in their org without being a member of that team."
+        - "A duplicate name or slug within the same owning team returns 409; the same name/slug under a different team is allowed."
+        - "If slug is omitted it is derived from the name and normalized."
+      x-test-coverage:
+        - "TestCreateProject_Success: editor creates a project (201)."
+        - "TestCreateProject_ForbiddenForViewer: a viewer is refused (403)."
+        - "TestCreateProject_MissingName: missing name returns 400."
+        - "TestCreateProject_Duplicate: duplicate name/slug in the same team returns 409."
+        - "TestCreateProject_Unauthorized: unauthenticated request returns 401."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateProjectRequest"
+      responses:
+        "201":
+          description: Project created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResponse"
+        "400":
+          description: Invalid request (invalid body, invalid team_id, or missing name)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "403":
+          description: Forbidden (requester is not an editor of the team or an org admin)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Owning team not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "409":
+          description: A project with this name or slug already exists in the team
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+
+  /v1/projects/{id}:
+    get:
+      summary: Get a Project
+      description: |
+        Fetches a project by ID. The requester must be able to reach the
+        project — as a member of the owning team or of a team granted access.
+        Projects the requester cannot reach are reported as not found.
+      operationId: getProject
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - "An unknown project id, or one the requester cannot reach, returns 404."
+      x-test-coverage:
+        - "TestGetProject_Success: owning-team member fetches the project (200)."
+        - "TestGetProject_NotFoundForNonMember: a non-member gets 404."
+        - "TestGetProject_NotFound: an unknown id returns 404."
+      responses:
+        "200":
+          description: The project
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectResponse"
+        "400":
+          description: Invalid project id
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Project not found or not reachable by the requester
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+    delete:
+      summary: Delete a Project
+      description: |
+        Hard-deletes a project, cascading to its prompts (and their versions,
+        tags, and payloads) and dropping its access grants. The requester must
+        be an admin of the owning team or an admin of that team's organization.
+      operationId: deleteProject
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the project.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - "A non-admin member of the owning team is refused with 403."
+        - "An unknown project id returns 404."
+      x-test-coverage:
+        - "TestDeleteProject_Success: an owning-team admin deletes the project (204)."
+        - "TestDeleteProject_ForbiddenForNonAdmin: a non-admin is refused (403)."
+        - "TestDeleteProject_NotFound: an unknown id returns 404."
+      responses:
+        "204":
+          description: Project deleted successfully (No Content)
+        "400":
+          description: Invalid project id
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "403":
+          description: Forbidden (requester is not an admin of the owning team or org)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+
+  /v1/teams/{teamID}/projects:
+    get:
+      summary: List a Team's Projects
+      description: |
+        Lists the projects a team owns plus those granted to it. The requester
+        must be a member of the team.
+      operationId: listTeamProjects
+      tags:
+        - Projects
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: teamID
+          in: path
+          required: true
+          description: The ID of the team.
+          schema:
+            type: string
+            format: uuid
+      x-edge-cases:
+        - "A non-member of the team is refused with 403."
+        - "A team owning and granted nothing returns an empty array."
+      x-test-coverage:
+        - "TestListTeamProjects_Success: a member lists the team's owned projects (200)."
+        - "TestListTeamProjects_ForbiddenForNonMember: a non-member gets 403."
+      responses:
+        "200":
+          description: List of projects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectListResponse"
+        "400":
+          description: Invalid team id
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "403":
+          description: Forbidden (requester is not a member of the team)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+
+components:
+  schemas:
+    Project:
+      type: object
+      required:
+        - id
+        - owning_team_id
+        - name
+        - slug
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        owning_team_id:
+          type: string
+          format: uuid
+          description: The team that owns the project.
+        name:
+          type: string
+          description: Human-readable project name, unique within the owning team.
+        slug:
+          type: string
+          description: Normalized identifier, unique within the owning team.
+        created_at:
+          type: string
+          format: date-time
+    CreateProjectRequest:
+      type: object
+      required:
+        - team_id
+        - name
+      properties:
+        team_id:
+          type: string
+          format: uuid
+          description: The team that will own the project.
+        name:
+          type: string
+          description: Human-readable project name.
+        slug:
+          type: string
+          description: Optional normalized slug; derived from the name when omitted.
+    ProjectResponse:
+      type: object
+      required:
+        - project
+      properties:
+        project:
+          $ref: "#/components/schemas/Project"
+    ProjectListResponse:
+      type: object
+      required:
+        - projects
+      properties:
+        projects:
+          type: array
+          items:
+            $ref: "#/components/schemas/Project"

--- a/docs/openapi/projects.yaml
+++ b/docs/openapi/projects.yaml
@@ -77,7 +77,7 @@ paths:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
 
-  /v1/projects/{id}:
+  /v1/projects/{projectID}:
     get:
       summary: Get a Project
       description: |
@@ -90,7 +90,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.
@@ -146,7 +146,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.
@@ -194,7 +194,7 @@ paths:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
 
-  /v1/projects/{id}/access:
+  /v1/projects/{projectID}/access:
     post:
       summary: Grant Project Access
       description: |
@@ -208,7 +208,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.
@@ -272,7 +272,7 @@ paths:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
 
-  /v1/projects/{id}/access/{teamID}:
+  /v1/projects/{projectID}/access/{teamID}:
     delete:
       summary: Revoke Project Access
       description: |
@@ -285,7 +285,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: projectID
           in: path
           required: true
           description: The ID of the project.

--- a/docs/openapi/prompt-renders.yaml
+++ b/docs/openapi/prompt-renders.yaml
@@ -3,20 +3,27 @@ info:
   title: Prompt Rendering API
   version: 1.0.0
 paths:
-  /v1/prompts/{slug}/render:
+  /v1/projects/{projectID}/prompts/{slug}/render:
     post:
       summary: Render Live Prompt Version
-      description: Renders the active 'live' template version of a prompt using supplied variables.
+      description: Renders the active 'live' template version of a prompt using supplied variables. The prompt is resolved by slug within the given project, so the same slug may be reused across projects.
       operationId: renderLive
       tags:
         - Prompt Renders
       security:
         - BearerAuth: []
       parameters:
+        - name: projectID
+          in: path
+          required: true
+          description: The ID of the project the prompt belongs to.
+          schema:
+            type: string
+            format: uuid
         - name: slug
           in: path
           required: true
-          description: Unique prompt slug.
+          description: Prompt slug, unique within the project.
           schema:
             type: string
       x-edge-cases:
@@ -86,20 +93,27 @@ paths:
               example:
                 error: "internal error"
 
-  /v1/prompts/{slug}/versions/{version}/render:
+  /v1/projects/{projectID}/prompts/{slug}/versions/{version}/render:
     post:
       summary: Render Specific Prompt Version
-      description: Renders a specific template version of a prompt (even draft status) using supplied variables.
+      description: Renders a specific template version of a prompt (even draft status) using supplied variables. The prompt is resolved by slug within the given project.
       operationId: renderVersion
       tags:
         - Prompt Renders
       security:
         - BearerAuth: []
       parameters:
+        - name: projectID
+          in: path
+          required: true
+          description: The ID of the project the prompt belongs to.
+          schema:
+            type: string
+            format: uuid
         - name: slug
           in: path
           required: true
-          description: Unique prompt slug.
+          description: Prompt slug, unique within the project.
           schema:
             type: string
         - name: version

--- a/docs/openapi/prompts.yaml
+++ b/docs/openapi/prompts.yaml
@@ -3,26 +3,31 @@ info:
   title: Prompts & Rendering API
   version: 1.0.0
 paths:
-  /v1/teams/{teamID}/prompts:
+  /v1/projects/{projectID}/prompts:
     post:
       summary: Create a Prompt
-      description: Creates a new prompt container.
+      description: Creates a new prompt inside a project. The requester must be an editor-or-above on the project (via the owning team or a granted team).
       operationId: createPrompt
       tags:
         - Prompts
       security:
         - BearerAuth: []
       parameters:
-        - name: teamID
+        - name: projectID
           in: path
           required: true
           schema:
             type: string
             format: uuid
-          description: The ID of the team.
+          description: The ID of the project.
+      x-edge-cases:
+        - "A viewer of the project is refused with 403; an unknown project returns 404."
+        - "Slug uniqueness is scoped to the project, so the same slug may exist in another project."
       x-test-coverage:
         - "TestCreatePrompt_Success: Verifies prompt creation and response payload."
         - "TestCreatePrompt_MissingName: Verifies that missing name returns 400 and 'name is required'."
+        - "TestCreatePrompt_ForbiddenForViewer: Verifies a viewer cannot create a prompt (403)."
+        - "TestCreatePrompt_UnknownProject: Verifies an unknown project returns 404."
         - "TestCreatePrompt_Unauthorized: Verifies that unauthenticated request returns 401."
       requestBody:
         required: true
@@ -61,6 +66,24 @@ paths:
                 $ref: "./auth.yaml#/components/schemas/APIError"
               example:
                 error: "unauthorized"
+        "403":
+          description: Forbidden (requester is not an editor of the project)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "409":
+          description: A prompt with this name or slug already exists in the project
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
         "500":
           description: Internal Server Error
           content:
@@ -72,20 +95,20 @@ paths:
 
     get:
       summary: List Prompts
-      description: Lists all available prompt containers.
+      description: Lists the prompts inside a project. The requester must be able to reach the project.
       operationId: listPrompts
       tags:
         - Prompts
       security:
         - BearerAuth: []
       parameters:
-        - name: teamID
+        - name: projectID
           in: path
           required: true
           schema:
             type: string
             format: uuid
-          description: The ID of the team.
+          description: The ID of the project.
         - name: archived
           in: query
           required: false
@@ -117,6 +140,18 @@ paths:
                 $ref: "./auth.yaml#/components/schemas/APIError"
               example:
                 error: "unauthorized"
+        "403":
+          description: Forbidden (requester cannot reach the project)
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "404":
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
         "500":
           description: Internal Server Error
           content:
@@ -128,25 +163,25 @@ paths:
 
   /v1/prompts:
     get:
-      summary: List all prompts with team filter
-      description: Returns a list of prompts. If team_id query parameter is not provided, returns an empty list by default. Users can filter by a team they are a member of.
+      summary: List all prompts with project filter
+      description: Returns a list of prompts. If the project_id query parameter is not provided, returns an empty list by default. Users can filter by a project they can reach.
       operationId: listAllPrompts
       tags:
         - Prompts
       security:
         - BearerAuth: []
       parameters:
-        - name: team_id
+        - name: project_id
           in: query
           required: false
-          description: Optional UUID of the team to filter prompts (alias of team).
+          description: Optional UUID of the project to filter prompts (alias of project).
           schema:
             type: string
             format: uuid
-        - name: team
+        - name: project
           in: query
           required: false
-          description: Optional UUID of the team to filter prompts (alias of team_id).
+          description: Optional UUID of the project to filter prompts (alias of project_id).
           schema:
             type: string
             format: uuid
@@ -157,12 +192,12 @@ paths:
           schema:
             type: boolean
       x-edge-cases:
-        - "By default with no team_id query parameter, returns an empty list of prompts."
-        - "If a team_id is provided, checks if the user is a member of that team, otherwise returns 403 Forbidden."
+        - "By default with no project_id query parameter, returns an empty list of prompts."
+        - "If a project_id is provided, checks the requester can reach that project, otherwise returns 403 Forbidden."
       x-test-coverage:
-        - "TestListAllPrompts: Verifies that no team_id returns 200 with an empty list."
-        - "TestListAllPrompts: Verifies that a valid team_id returns 200 with prompts of that team."
-        - "TestListAllPrompts: Verifies that an unallowed team_id returns 403 Forbidden."
+        - "TestListAllPrompts: Verifies that no project_id returns 200 with an empty list."
+        - "TestListAllPrompts: Verifies that a valid project_id returns 200 with prompts of that project."
+        - "TestListAllPrompts: Verifies that an unallowed project_id returns 403 Forbidden."
       responses:
         "200":
           description: A list of prompts
@@ -485,7 +520,7 @@ paths:
   /v1/prompts/{id}/move:
     post:
       summary: Move a Prompt
-      description: Moves a prompt from its current team to another team. Requires admin privileges on both teams.
+      description: Moves a prompt from its current project to another project. Requires admin capability on both the source and target project (owning-team or org admin).
       operationId: movePrompt
       tags:
         - Prompts
@@ -498,6 +533,13 @@ paths:
           schema:
             type: string
             format: uuid
+      x-edge-cases:
+        - "Requires admin on both source and target project; a non-admin on either side is refused with 403."
+        - "A move into a project where the prompt's name or slug already exists is rejected with 409."
+        - "An unknown prompt or an unknown target project returns 404."
+      x-test-coverage:
+        - "TestMovePrompt: Verifies an admin moves a prompt between projects (200)."
+        - "TestMovePrompt_TargetCollision: Verifies a name/slug collision in the target project returns 409."
       requestBody:
         required: true
         content:
@@ -505,11 +547,12 @@ paths:
             schema:
               type: object
               required:
-                - team_id
+                - project_id
               properties:
-                team_id:
+                project_id:
                   type: string
                   format: uuid
+                  description: The target project to move the prompt into.
       responses:
         "200":
           description: Prompt successfully moved
@@ -523,7 +566,7 @@ paths:
                 required:
                   - prompt
         "400":
-          description: Invalid UUID format or team_id
+          description: Invalid UUID format or project_id
           content:
             application/json:
               schema:
@@ -535,13 +578,19 @@ paths:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
         "403":
-          description: Forbidden
+          description: Forbidden (not an admin on the source or target project)
           content:
             application/json:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
         "404":
-          description: Prompt not found
+          description: Prompt or target project not found
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+        "409":
+          description: A prompt with this name or slug already exists in the target project
           content:
             application/json:
               schema:
@@ -556,13 +605,13 @@ components:
           type: string
           format: uuid
           description: Unique identifier.
-        team_id:
+        project_id:
           type: string
           format: uuid
-          description: Unique identifier of the team.
+          description: Unique identifier of the project the prompt belongs to.
         slug:
           type: string
-          description: Unique slug within the team.
+          description: Unique slug within the project.
         name:
           type: string
           description: Name of the prompt container.
@@ -581,7 +630,7 @@ components:
           format: date-time
       required:
         - id
-        - team_id
+        - project_id
         - slug
         - name
         - description

--- a/docs/openapi/prompts.yaml
+++ b/docs/openapi/prompts.yaml
@@ -115,9 +115,14 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+      x-edge-cases:
+        - "An API key reaches the prompts of every project its teams can access — owned or granted — and loses that reach when the grant is revoked."
       x-test-coverage:
         - "TestListPrompts: Verifies listing populated prompt containers."
         - "TestListPrompts_Empty: Verifies that listing when empty returns an empty array."
+        - "TestPrompts_APIKeyAuth: Verifies an API key lists a project owned by its team."
+        - "TestAPIKey_ReachesGrantedProject: Verifies an API key reaches a granted project's prompts and is denied after revoke."
+        - "TestAPIKey_DeniedForeignProject: Verifies an API key is denied a project its teams cannot access."
       responses:
         "200":
           description: List of prompts

--- a/internal/apierr/errors.go
+++ b/internal/apierr/errors.go
@@ -66,6 +66,7 @@ var (
 	ErrForbidden                = &APIError{Status: fiber.StatusForbidden, Message: "forbidden"}
 	ErrUnauthorized             = &APIError{Status: fiber.StatusUnauthorized, Message: "unauthorized"}
 	ErrPromptNotFound           = &APIError{Status: fiber.StatusNotFound, Message: "prompt not found"}
+	ErrProjectNotFound          = &APIError{Status: fiber.StatusNotFound, Message: "project not found"}
 	ErrPayloadNotFound          = &APIError{Status: fiber.StatusNotFound, Message: "payload not found"}
 	ErrInvalidPayloadID         = &APIError{Status: fiber.StatusBadRequest, Message: "invalid payload id"}
 	ErrPayloadVariablesRequired = &APIError{Status: fiber.StatusBadRequest, Message: "payload variables are required"}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -63,6 +63,8 @@ func New() *fiber.App {
 	projects.Post("", handler.CreateProject)
 	projects.Get("/:id", handler.GetProject)
 	projects.Delete("/:id", handler.DeleteProject)
+	projects.Post("/:id/access", handler.GrantProjectAccess)
+	projects.Delete("/:id/access/:teamID", handler.RevokeProjectAccess)
 
 	teams := v1.Group("/teams", middleware.RequireAccessToken)
 	teams.Get("/:teamID/projects", handler.ListTeamProjects)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,16 +55,16 @@ func New() *fiber.App {
 	orgs.Get("/:orgID/people", handler.ListOrgPeople)
 	orgs.Delete("/:orgID/members/:userID", handler.RemoveOrgMember)
 
-	teamPrompts := v1.Group("/teams/:teamID/prompts", middleware.RequireAuth)
-	teamPrompts.Post("", handler.CreatePrompt)
-	teamPrompts.Get("", handler.ListPrompts)
-
 	projects := v1.Group("/projects", middleware.RequireAuth)
 	projects.Post("", handler.CreateProject)
-	projects.Get("/:id", handler.GetProject)
-	projects.Delete("/:id", handler.DeleteProject)
-	projects.Post("/:id/access", handler.GrantProjectAccess)
-	projects.Delete("/:id/access/:teamID", handler.RevokeProjectAccess)
+	projects.Get("/:projectID", handler.GetProject)
+	projects.Delete("/:projectID", handler.DeleteProject)
+	projects.Post("/:projectID/access", handler.GrantProjectAccess)
+	projects.Delete("/:projectID/access/:teamID", handler.RevokeProjectAccess)
+	projects.Post("/:projectID/prompts", handler.CreatePrompt)
+	projects.Get("/:projectID/prompts", handler.ListPrompts)
+	projects.Post("/:projectID/prompts/:slug/render", handler.RenderLive)
+	projects.Post("/:projectID/prompts/:slug/versions/:version/render", handler.RenderVersion)
 
 	teams := v1.Group("/teams", middleware.RequireAccessToken)
 	teams.Get("/:teamID/projects", handler.ListTeamProjects)
@@ -93,8 +93,6 @@ func New() *fiber.App {
 	prompts.Post("/:id/move", handler.MovePrompt)
 	prompts.Get("/:id/versions/diff", handler.DiffVersions)
 
-	prompts.Post("/:slug/render", handler.RenderLive)
-
 	prompts.Post("/:id/versions", handler.CreateVersion)
 	prompts.Get("/:id/versions", handler.ListVersions)
 	prompts.Get("/:id/versions/:version", handler.GetVersion)
@@ -104,7 +102,6 @@ func New() *fiber.App {
 	prompts.Post("/:id/versions/:version/demote", handler.DemoteVersion)
 	prompts.Post("/:id/versions/:version/archive", handler.ArchiveVersion)
 	prompts.Post("/:id/versions/:version/duplicate", handler.DuplicateVersion)
-	prompts.Post("/:slug/versions/:version/render", handler.RenderVersion)
 	prompts.Post("/:id/versions/:version/tags", handler.SetTag)
 	prompts.Delete("/:id/tags/:tag", handler.RemoveTag)
 	prompts.Get("/:id/tags", handler.ListTags)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -59,7 +59,13 @@ func New() *fiber.App {
 	teamPrompts.Post("", handler.CreatePrompt)
 	teamPrompts.Get("", handler.ListPrompts)
 
+	projects := v1.Group("/projects", middleware.RequireAuth)
+	projects.Post("", handler.CreateProject)
+	projects.Get("/:id", handler.GetProject)
+	projects.Delete("/:id", handler.DeleteProject)
+
 	teams := v1.Group("/teams", middleware.RequireAccessToken)
+	teams.Get("/:teamID/projects", handler.ListTeamProjects)
 	teams.Put("/:id", handler.UpdateTeam)
 	teams.Post("/:id/members", handler.AddTeamMember)
 	teams.Delete("/:id/members/:userID", handler.RemoveTeamMember)

--- a/internal/db/migrations/020_projects.sql
+++ b/internal/db/migrations/020_projects.sql
@@ -1,0 +1,21 @@
+-- Projects: a named container for prompts that sits between Team and Prompt.
+-- A project belongs to exactly one owning team and may grant access to
+-- additional teams in the same organization (issue #12).
+
+CREATE TABLE projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owning_team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_projects_team_name UNIQUE (owning_team_id, name),
+    CONSTRAINT uq_projects_team_slug UNIQUE (owning_team_id, slug)
+);
+
+-- Access grants: an additional team that may work with the project's prompts.
+-- The owning team's access is implicit and is never stored here.
+CREATE TABLE project_team_access (
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    PRIMARY KEY (project_id, team_id)
+);

--- a/internal/db/migrations/021_prompts_to_projects.sql
+++ b/internal/db/migrations/021_prompts_to_projects.sql
@@ -1,0 +1,49 @@
+-- Prompts move from belonging directly to a Team to belonging to a Project
+-- (issue #12, breaking change). Existing prompts are backfilled into one
+-- default project per team that owns prompts.
+
+-- 1. Add the project reference (nullable during backfill). Deleting a project
+--    cascades to its prompts.
+ALTER TABLE prompts ADD COLUMN project_id UUID REFERENCES projects(id) ON DELETE CASCADE;
+
+-- 2. Backfill: every team that owns at least one prompt gets exactly one default
+--    project (owned by that team, name/slug derived from the team); its prompts
+--    move into that project. Teams with no prompts get no project.
+DO $$
+DECLARE
+    t RECORD;
+    new_project_id UUID;
+BEGIN
+    FOR t IN
+        SELECT tm.id AS team_id, tm.name AS team_name
+        FROM teams tm
+        WHERE EXISTS (SELECT 1 FROM prompts p WHERE p.team_id = tm.id)
+    LOOP
+        INSERT INTO projects (owning_team_id, name, slug)
+        VALUES (
+            t.team_id,
+            t.team_name || ' Default Project',
+            COALESCE(
+                NULLIF(trim(both '_' from regexp_replace(lower(t.team_name || ' default project'), '[^a-z0-9_]+', '_', 'g')), ''),
+                'default_project'
+            )
+        )
+        RETURNING id INTO new_project_id;
+
+        UPDATE prompts SET project_id = new_project_id WHERE team_id = t.team_id;
+    END LOOP;
+END $$;
+
+-- 3. Any prompt still without a project is an invalid orphan; drop it before
+--    enforcing NOT NULL (defensive - migration 013 already forbids null team_id).
+DELETE FROM prompts WHERE project_id IS NULL;
+
+-- 4. Swap team-scoped uniqueness for project-scoped uniqueness and drop team_id.
+ALTER TABLE prompts DROP CONSTRAINT IF EXISTS uq_prompts_team_name;
+ALTER TABLE prompts DROP CONSTRAINT IF EXISTS uq_prompts_team_slug;
+
+ALTER TABLE prompts ALTER COLUMN project_id SET NOT NULL;
+ALTER TABLE prompts DROP COLUMN team_id;
+
+ALTER TABLE prompts ADD CONSTRAINT uq_prompts_project_name UNIQUE (project_id, name);
+ALTER TABLE prompts ADD CONSTRAINT uq_prompts_project_slug UNIQUE (project_id, slug);

--- a/internal/handler/apikey_projects_test.go
+++ b/internal/handler/apikey_projects_test.go
@@ -1,0 +1,108 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/px0-ai/px0/internal/store"
+)
+
+// createAPIKeyForTeam creates an "all" API key scoped to a single team and
+// returns the raw key.
+func createAPIKeyForTeam(t *testing.T, a *testApp, token, orgID, teamID string) string {
+	t.Helper()
+	req := newReq(t, http.MethodPost, "/v1/api-keys",
+		fmt.Sprintf(`{"name":"scoped-key","org_id":%q,"operation":"all","team_ids":[%q]}`, orgID, teamID), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	return decodeBody(t, resp)["key"].(string)
+}
+
+// TestAPIKey_ReachesGrantedProject verifies that an API key scoped to a team
+// reaches the prompts of a project granted to that team — and loses that reach
+// when the grant is revoked or for a project the team cannot access.
+func TestAPIKey_ReachesGrantedProject(t *testing.T) {
+	a := newTestApp(t)
+	ctx := context.Background()
+
+	adminToken := setupUser(t, a)
+	adminSession, err := store.GetSessionByToken(ctx, adminToken)
+	require.NoError(t, err)
+	teams, err := store.GetUserTeams(ctx, adminSession.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	ownerTeam := teams[0]
+	require.NotNil(t, ownerTeam.OrgID)
+	orgID := *ownerTeam.OrgID
+
+	// A grantee team in the same org, and an API key scoped to it.
+	granteeTeam, err := store.CreateTeamWithOrg(ctx, "Key Grantee Team", orgID)
+	require.NoError(t, err)
+	apiKey := createAPIKeyForTeam(t, a, adminToken, orgID.String(), granteeTeam.ID.String())
+
+	// A project owned by ownerTeam (not the key's team) with a prompt inside.
+	project, err := store.CreateProject(ctx, ownerTeam.ID, "shared_with_key", "Shared With Key")
+	require.NoError(t, err)
+	_, err = store.CreatePrompt(ctx, project.ID, "greeting", "Greeting", "")
+	require.NoError(t, err)
+
+	listWithKey := func() int {
+		req := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", project.ID), "", apiKey)
+		resp, err := a.Test(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	// 1. Before any grant, the key's team cannot reach the project.
+	assert.Equal(t, http.StatusForbidden, listWithKey())
+
+	// 2. After granting the key's team access, the key reaches the prompts.
+	require.NoError(t, store.GrantProjectAccess(ctx, project.ID, granteeTeam.ID))
+	req := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", project.ID), "", apiKey)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	prompts := decodeBody(t, resp)["prompts"].([]any)
+	assert.Len(t, prompts, 1)
+
+	// 3. After revoking the grant, reach is lost again.
+	require.NoError(t, store.RevokeProjectAccess(ctx, project.ID, granteeTeam.ID))
+	assert.Equal(t, http.StatusForbidden, listWithKey())
+}
+
+// TestAPIKey_DeniedForeignProject verifies an API key cannot reach a project
+// owned by a team outside its scope with no grant.
+func TestAPIKey_DeniedForeignProject(t *testing.T) {
+	a := newTestApp(t)
+	ctx := context.Background()
+
+	adminToken := setupUser(t, a)
+	adminSession, err := store.GetSessionByToken(ctx, adminToken)
+	require.NoError(t, err)
+	teams, err := store.GetUserTeams(ctx, adminSession.UserID)
+	require.NoError(t, err)
+	ownerTeam := teams[0]
+	orgID := *ownerTeam.OrgID
+
+	// Key scoped to a team that owns and is granted nothing.
+	keyTeam, err := store.CreateTeamWithOrg(ctx, "Lonely Key Team", orgID)
+	require.NoError(t, err)
+	apiKey := createAPIKeyForTeam(t, a, adminToken, orgID.String(), keyTeam.ID.String())
+
+	// A project owned by ownerTeam, never shared with keyTeam.
+	project, err := store.CreateProject(ctx, ownerTeam.ID, "private_project", "Private Project")
+	require.NoError(t, err)
+
+	req := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", project.ID), "", apiKey)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}

--- a/internal/handler/apikey_test.go
+++ b/internal/handler/apikey_test.go
@@ -272,8 +272,11 @@ func TestCreateAPIKey_GlobalScope(t *testing.T) {
 	apiKey := body["key"].(string)
 	resp.Body.Close()
 
-	// 2. Use the Global API key to list prompts (should succeed and resolve teams globally)
-	reqPrompts := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teams[0].ID.String()), "", apiKey)
+	// 2. Use the Global API key to list a project's prompts (should succeed and
+	//    resolve teams globally to reach the project owned by teams[0]).
+	project, err := store.CreateProject(context.Background(), teams[0].ID, "global_scope", "Global Scope")
+	require.NoError(t, err)
+	reqPrompts := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", project.ID.String()), "", apiKey)
 	respPrompts, err := a.Test(reqPrompts)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, respPrompts.StatusCode)

--- a/internal/handler/helpers.go
+++ b/internal/handler/helpers.go
@@ -106,6 +106,46 @@ func getRequestAdminTeamIDs(c *fiber.Ctx) ([]uuid.UUID, error) {
 	return teamIDs, nil
 }
 
+// containsUUID reports whether target is present in ids.
+func containsUUID(ids []uuid.UUID, target uuid.UUID) bool {
+	for _, id := range ids {
+		if id == target {
+			return true
+		}
+	}
+	return false
+}
+
+// getRequestViewerProjectIDs returns the IDs of every project the requester can
+// reach at viewer-or-above capability — their teams (owned + granted projects).
+func getRequestViewerProjectIDs(c *fiber.Ctx) ([]uuid.UUID, error) {
+	teamIDs, err := getRequestTeamIDs(c)
+	if err != nil {
+		return nil, err
+	}
+	return store.ListAccessibleProjectIDs(c.Context(), teamIDs)
+}
+
+// getRequestEditorProjectIDs returns the IDs of projects the requester can reach
+// with editor-or-above capability.
+func getRequestEditorProjectIDs(c *fiber.Ctx) ([]uuid.UUID, error) {
+	teamIDs, err := getRequestEditorTeamIDs(c)
+	if err != nil {
+		return nil, err
+	}
+	return store.ListAccessibleProjectIDs(c.Context(), teamIDs)
+}
+
+// getRequestAdminProjectIDs returns the IDs of projects the requester can reach
+// with admin capability.
+func getRequestAdminProjectIDs(c *fiber.Ctx) ([]uuid.UUID, error) {
+	teamIDs, err := getRequestAdminTeamIDs(c)
+	if err != nil {
+		return nil, err
+	}
+	return store.ListAccessibleProjectIDs(c.Context(), teamIDs)
+}
+
 func IsOrgAdmin(c *fiber.Ctx, orgID uuid.UUID) (bool, error) {
 	if op, ok := c.Locals("apiKeyOperation").(string); ok {
 		if op == "admin" || op == "all" {

--- a/internal/handler/helpers_test.go
+++ b/internal/handler/helpers_test.go
@@ -123,20 +123,26 @@ func setupUser(t *testing.T, a *testApp) string {
 	return body["token"].(string)
 }
 
-// setupPrompt creates a prompt and returns its ID.
-func setupPrompt(t *testing.T, a *testApp, token string) string {
+// setupProject creates a project owned by the user's first team and returns its ID.
+func setupProject(t *testing.T, a *testApp, token string) string {
 	t.Helper()
-	ctx := context.Background()
-	session, err := store.GetSessionByToken(ctx, token)
+	teamID := setupUserTeam(t, token)
+	name := fmt.Sprintf("Test Project %s", uuid.New().String())
+	req := newReq(t, http.MethodPost, "/v1/projects",
+		fmt.Sprintf(`{"team_id":%q,"name":%q}`, teamID, name), token)
+	resp, err := a.Test(req)
 	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "create project failed")
 
-	teams, err := store.GetUserTeams(ctx, session.UserID)
-	require.NoError(t, err)
-	require.NotEmpty(t, teams, "User has no teams")
-	teamID := teams[0].ID
+	body := decodeBody(t, resp)
+	return body["project"].(map[string]any)["id"].(string)
+}
 
+// setupPromptInProject creates a prompt inside the given project and returns its ID.
+func setupPromptInProject(t *testing.T, a *testApp, token, projectID string) string {
+	t.Helper()
 	uniqueName := fmt.Sprintf("Test Prompt %s", uuid.New().String())
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		fmt.Sprintf(`{"name":%q,"description":"A test prompt"}`, uniqueName), token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -144,6 +150,13 @@ func setupPrompt(t *testing.T, a *testApp, token string) string {
 
 	body := decodeBody(t, resp)
 	return body["prompt"].(map[string]any)["id"].(string)
+}
+
+// setupPrompt creates a project and a prompt inside it, returning the prompt ID.
+func setupPrompt(t *testing.T, a *testApp, token string) string {
+	t.Helper()
+	projectID := setupProject(t, a, token)
+	return setupPromptInProject(t, a, token, projectID)
 }
 
 // setupVersion creates a draft version and returns its version number.

--- a/internal/handler/payload.go
+++ b/internal/handler/payload.go
@@ -27,24 +27,24 @@ func CreatePromptPayload(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -83,12 +83,12 @@ func GetPromptPayload(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPayloadID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
@@ -112,12 +112,12 @@ func ListPromptPayloads(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
@@ -149,24 +149,24 @@ func UpdatePromptPayload(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPayloadID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -204,24 +204,24 @@ func DeletePromptPayload(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPayloadID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}

--- a/internal/handler/project.go
+++ b/internal/handler/project.go
@@ -96,7 +96,7 @@ func CreateProject(c *fiber.Ctx) error {
 }
 
 func GetProject(c *fiber.Ctx) error {
-	id, err := uuid.Parse(c.Params("id"))
+	id, err := uuid.Parse(c.Params("projectID"))
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}
@@ -194,7 +194,7 @@ func requireProjectAdmin(c *fiber.Ctx, projectID uuid.UUID) (project *model.Proj
 }
 
 func GrantProjectAccess(c *fiber.Ctx) error {
-	projectID, err := uuid.Parse(c.Params("id"))
+	projectID, err := uuid.Parse(c.Params("projectID"))
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}
@@ -246,7 +246,7 @@ func GrantProjectAccess(c *fiber.Ctx) error {
 }
 
 func RevokeProjectAccess(c *fiber.Ctx) error {
-	projectID, err := uuid.Parse(c.Params("id"))
+	projectID, err := uuid.Parse(c.Params("projectID"))
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}
@@ -269,7 +269,7 @@ func RevokeProjectAccess(c *fiber.Ctx) error {
 }
 
 func DeleteProject(c *fiber.Ctx) error {
-	id, err := uuid.Parse(c.Params("id"))
+	id, err := uuid.Parse(c.Params("projectID"))
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}

--- a/internal/handler/project.go
+++ b/internal/handler/project.go
@@ -1,0 +1,193 @@
+package handler
+
+import (
+	"errors"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	"github.com/px0-ai/px0/internal/apierr"
+	"github.com/px0-ai/px0/internal/model"
+	"github.com/px0-ai/px0/internal/store"
+)
+
+// isProjectEditor reports whether the requester may create projects owned by the
+// given team: an editor-or-above member of the team, or an admin of its org.
+func isProjectEditor(c *fiber.Ctx, team *model.Team) (bool, error) {
+	isEditor, err := IsTeamEditor(c, team.ID)
+	if err != nil {
+		return false, err
+	}
+	if isEditor {
+		return true, nil
+	}
+	if team.OrgID != nil {
+		return IsOrgAdmin(c, *team.OrgID)
+	}
+	return false, nil
+}
+
+// isProjectAdmin reports whether the requester may administer the given team's
+// projects (delete, grant, revoke): an admin of the team, or an admin of its org.
+func isProjectAdmin(c *fiber.Ctx, team *model.Team) (bool, error) {
+	isAdmin, err := IsTeamAdmin(c, team.ID)
+	if err != nil {
+		return false, err
+	}
+	if isAdmin {
+		return true, nil
+	}
+	if team.OrgID != nil {
+		return IsOrgAdmin(c, *team.OrgID)
+	}
+	return false, nil
+}
+
+type createProjectRequest struct {
+	TeamID string `json:"team_id"`
+	Name   string `json:"name"`
+	Slug   string `json:"slug"`
+}
+
+func CreateProject(c *fiber.Ctx) error {
+	var req createProjectRequest
+	if err := c.BodyParser(&req); err != nil {
+		return apierr.ErrInvalidRequestBody.Respond(c)
+	}
+
+	teamID, err := uuid.Parse(req.TeamID)
+	if err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid team_id").Respond(c)
+	}
+	if req.Name == "" {
+		return apierr.ErrNameRequired.Respond(c)
+	}
+
+	team, err := store.GetTeamByID(c.Context(), teamID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.NewAPIError(fiber.StatusNotFound, "team not found").Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	allowed, err := isProjectEditor(c, team)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if !allowed {
+		return apierr.ErrForbidden.Respond(c)
+	}
+
+	slug := req.Slug
+	if slug == "" {
+		slug = req.Name
+	}
+	slug = NormalizeSlug(slug)
+
+	project, err := store.CreateProject(c.Context(), teamID, slug, req.Name)
+	if err != nil {
+		if errors.Is(err, store.ErrDuplicate) {
+			return apierr.NewAPIError(fiber.StatusConflict, "project with this name or slug already exists in the team; please provide a unique name").Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"project": project})
+}
+
+func GetProject(c *fiber.Ctx) error {
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
+
+	teamIDs, err := getRequestTeamIDs(c)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	accessible, err := store.IsProjectAccessibleByTeams(c.Context(), id, teamIDs)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if !accessible {
+		return apierr.ErrProjectNotFound.Respond(c)
+	}
+
+	project, err := store.GetProjectByID(c.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrProjectNotFound.Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return c.JSON(fiber.Map{"project": project})
+}
+
+func ListTeamProjects(c *fiber.Ctx) error {
+	teamID, err := uuid.Parse(c.Params("teamID"))
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
+
+	allowedIDs, err := getRequestTeamIDs(c)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	isMember := false
+	for _, tid := range allowedIDs {
+		if tid == teamID {
+			isMember = true
+			break
+		}
+	}
+	if !isMember {
+		return apierr.ErrForbidden.Respond(c)
+	}
+
+	projects, err := store.ListProjectsForTeam(c.Context(), teamID)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if projects == nil {
+		projects = []*model.Project{}
+	}
+	return c.JSON(fiber.Map{"projects": projects})
+}
+
+func DeleteProject(c *fiber.Ctx) error {
+	id, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
+
+	project, err := store.GetProjectByID(c.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrProjectNotFound.Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	team, err := store.GetTeamByID(c.Context(), project.OwningTeamID)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	allowed, err := isProjectAdmin(c, team)
+	if err != nil {
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if !allowed {
+		return apierr.ErrForbidden.Respond(c)
+	}
+
+	if err := store.DeleteProject(c.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrProjectNotFound.Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}

--- a/internal/handler/project.go
+++ b/internal/handler/project.go
@@ -156,31 +156,126 @@ func ListTeamProjects(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"projects": projects})
 }
 
+type grantProjectAccessRequest struct {
+	TeamID string `json:"team_id"`
+}
+
+// requireProjectAdmin loads the project and its owning team and verifies the
+// requester is an admin of the owning team (or its org). When it returns
+// ok == false it has already written the appropriate error response to c, and
+// the caller should return nil.
+func requireProjectAdmin(c *fiber.Ctx, projectID uuid.UUID) (project *model.Project, team *model.Team, ok bool) {
+	project, err := store.GetProjectByID(c.Context(), projectID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			_ = apierr.ErrProjectNotFound.Respond(c)
+		} else {
+			_ = apierr.ErrInternalError.Respond(c, err)
+		}
+		return nil, nil, false
+	}
+
+	team, err = store.GetTeamByID(c.Context(), project.OwningTeamID)
+	if err != nil {
+		_ = apierr.ErrInternalError.Respond(c, err)
+		return nil, nil, false
+	}
+
+	allowed, err := isProjectAdmin(c, team)
+	if err != nil {
+		_ = apierr.ErrInternalError.Respond(c, err)
+		return nil, nil, false
+	}
+	if !allowed {
+		_ = apierr.ErrForbidden.Respond(c)
+		return nil, nil, false
+	}
+	return project, team, true
+}
+
+func GrantProjectAccess(c *fiber.Ctx) error {
+	projectID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
+
+	var req grantProjectAccessRequest
+	if err := c.BodyParser(&req); err != nil {
+		return apierr.ErrInvalidRequestBody.Respond(c)
+	}
+	granteeID, err := uuid.Parse(req.TeamID)
+	if err != nil {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid team_id").Respond(c)
+	}
+
+	project, owningTeam, ok := requireProjectAdmin(c, projectID)
+	if !ok {
+		return nil
+	}
+
+	// Sharing is bounded to the owning team's organization; an org-less team
+	// may hold a private project but cannot share it.
+	if owningTeam.OrgID == nil {
+		return apierr.NewAPIError(fiber.StatusForbidden, "the project's owning team has no organization; sharing is not available").Respond(c)
+	}
+
+	if granteeID == project.OwningTeamID {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "the owning team already has implicit access").Respond(c)
+	}
+
+	grantee, err := store.GetTeamByID(c.Context(), granteeID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.NewAPIError(fiber.StatusNotFound, "team not found").Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	if grantee.OrgID == nil || *grantee.OrgID != *owningTeam.OrgID {
+		return apierr.NewAPIError(fiber.StatusForbidden, "grantee team must belong to the owning team's organization").Respond(c)
+	}
+
+	if err := store.GrantProjectAccess(c.Context(), projectID, granteeID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrProjectNotFound.Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
+		"access": fiber.Map{"project_id": projectID, "team_id": granteeID},
+	})
+}
+
+func RevokeProjectAccess(c *fiber.Ctx) error {
+	projectID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
+	granteeID, err := uuid.Parse(c.Params("teamID"))
+	if err != nil {
+		return apierr.ErrInvalidID.Respond(c)
+	}
+
+	if _, _, ok := requireProjectAdmin(c, projectID); !ok {
+		return nil
+	}
+
+	if err := store.RevokeProjectAccess(c.Context(), projectID, granteeID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.NewAPIError(fiber.StatusNotFound, "access grant not found").Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
 func DeleteProject(c *fiber.Ctx) error {
 	id, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}
 
-	project, err := store.GetProjectByID(c.Context(), id)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return apierr.ErrProjectNotFound.Respond(c)
-		}
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-
-	team, err := store.GetTeamByID(c.Context(), project.OwningTeamID)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-
-	allowed, err := isProjectAdmin(c, team)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-	if !allowed {
-		return apierr.ErrForbidden.Respond(c)
+	if _, _, ok := requireProjectAdmin(c, id); !ok {
+		return nil
 	}
 
 	if err := store.DeleteProject(c.Context(), id); err != nil {

--- a/internal/handler/project_test.go
+++ b/internal/handler/project_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,7 @@ type projectRoles struct {
 	viewerToken   string
 	outsiderToken string
 	teamID        string
+	orgID         uuid.UUID
 }
 
 // setupProjectRoles builds a team (via the admin from setupUser) with an editor,
@@ -38,6 +40,8 @@ func setupProjectRoles(t *testing.T, a *testApp) projectRoles {
 	require.NoError(t, err)
 	require.NotEmpty(t, teams)
 	teamID := teams[0].ID
+	require.NotNil(t, teams[0].OrgID)
+	orgID := *teams[0].OrgID
 
 	newMember := func(email, role string, join bool) string {
 		hash, err := bcrypt.GenerateFromPassword([]byte("Password123!"), bcrypt.DefaultCost)
@@ -61,7 +65,30 @@ func setupProjectRoles(t *testing.T, a *testApp) projectRoles {
 		viewerToken:   newMember("proj-viewer@px0.dev", "viewer", true),
 		outsiderToken: newMember("proj-outsider@px0.dev", "", false),
 		teamID:        teamID.String(),
+		orgID:         orgID,
 	}
+}
+
+// makeTeamMember creates a verified user in the given team (defaulting to the
+// role AddTeamMember assigns) and returns a session token for them.
+func makeTeamMember(t *testing.T, teamID uuid.UUID, email string, expiresAt time.Time) string {
+	t.Helper()
+	ctx := context.Background()
+	hash, err := bcrypt.GenerateFromPassword([]byte("Password123!"), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	u, err := store.CreateVerifiedUser(ctx, email, string(hash))
+	require.NoError(t, err)
+	require.NoError(t, store.AddTeamMember(ctx, teamID, u.ID))
+	sess, err := store.CreateSession(ctx, u.ID, "sess_"+uuid.NewString(), expiresAt)
+	require.NoError(t, err)
+	return sess.Token
+}
+
+func sessionExpiry(t *testing.T, token string) time.Time {
+	t.Helper()
+	sess, err := store.GetSessionByToken(context.Background(), token)
+	require.NoError(t, err)
+	return sess.ExpiresAt
 }
 
 func createProjectBody(teamID, name string) string {
@@ -242,4 +269,147 @@ func TestListTeamProjects_ForbiddenForNonMember(t *testing.T) {
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func grantAccessBody(teamID string) string {
+	return fmt.Sprintf(`{"team_id":%q}`, teamID)
+}
+
+func TestGrantProjectAccess_Success(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	ctx := context.Background()
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	// A second team in the same org, with a member who is not on the owning team.
+	grantee, err := store.CreateTeamWithOrg(ctx, "Grantee Team", r.orgID)
+	require.NoError(t, err)
+	granteeToken := makeTeamMember(t, grantee.ID, "grantee-member@px0.dev", sessionExpiry(t, r.adminToken))
+
+	// Before the grant, the grantee member cannot reach the project.
+	resp, err := a.Test(newReq(t, http.MethodGet, "/v1/projects/"+id, "", granteeToken))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+
+	// Owning-team admin grants access.
+	resp, err = a.Test(newReq(t, http.MethodPost, "/v1/projects/"+id+"/access", grantAccessBody(grantee.ID.String()), r.adminToken))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	// Now the grantee member can reach the project.
+	resp, err = a.Test(newReq(t, http.MethodGet, "/v1/projects/"+id, "", granteeToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestGrantProjectAccess_ForbiddenForNonAdmin(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	ctx := context.Background()
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	grantee, err := store.CreateTeamWithOrg(ctx, "Grantee Team", r.orgID)
+	require.NoError(t, err)
+
+	resp, err := a.Test(newReq(t, http.MethodPost, "/v1/projects/"+id+"/access", grantAccessBody(grantee.ID.String()), r.editorToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestGrantProjectAccess_RejectsTeamOutsideOrg(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	ctx := context.Background()
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	// A team in a different organization.
+	foreignOrg, err := store.CreateOrganization(ctx, "Foreign Org")
+	require.NoError(t, err)
+	foreign, err := store.CreateTeamWithOrg(ctx, "Foreign Team", foreignOrg.ID)
+	require.NoError(t, err)
+
+	resp, err := a.Test(newReq(t, http.MethodPost, "/v1/projects/"+id+"/access", grantAccessBody(foreign.ID.String()), r.adminToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestGrantProjectAccess_RejectsOrgLessOwner(t *testing.T) {
+	a := newTestApp(t)
+	setupProjectRoles(t, a) // establishes an admin/session baseline
+	ctx := context.Background()
+
+	// An org-less owning team with an admin member and a private project.
+	orgLess, err := store.CreateTeam(ctx, "Org-less Team")
+	require.NoError(t, err)
+	ownerToken := makeTeamMember(t, orgLess.ID, "orgless-admin@px0.dev", time.Now().Add(time.Hour))
+	project, err := store.CreateProject(ctx, orgLess.ID, "private", "Private")
+	require.NoError(t, err)
+
+	// Some other team to attempt to share with.
+	other, err := store.CreateTeam(ctx, "Some Other Team")
+	require.NoError(t, err)
+
+	resp, err := a.Test(newReq(t, http.MethodPost, "/v1/projects/"+project.ID.String()+"/access", grantAccessBody(other.ID.String()), ownerToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestGrantProjectAccess_UnknownProject(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	resp, err := a.Test(newReq(t, http.MethodPost, "/v1/projects/"+uuid.NewString()+"/access", grantAccessBody(r.teamID), r.adminToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestRevokeProjectAccess_Success(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	ctx := context.Background()
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	grantee, err := store.CreateTeamWithOrg(ctx, "Grantee Team", r.orgID)
+	require.NoError(t, err)
+	granteeToken := makeTeamMember(t, grantee.ID, "grantee-member@px0.dev", sessionExpiry(t, r.adminToken))
+
+	require.NoError(t, store.GrantProjectAccess(ctx, uuid.MustParse(id), grantee.ID))
+
+	// Revoke, then the grantee loses reachability.
+	resp, err := a.Test(newReq(t, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/access/%s", id, grantee.ID), "", r.adminToken))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
+	resp, err = a.Test(newReq(t, http.MethodGet, "/v1/projects/"+id, "", granteeToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestRevokeProjectAccess_ForbiddenForNonAdmin(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	ctx := context.Background()
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	grantee, err := store.CreateTeamWithOrg(ctx, "Grantee Team", r.orgID)
+	require.NoError(t, err)
+	require.NoError(t, store.GrantProjectAccess(ctx, uuid.MustParse(id), grantee.ID))
+
+	resp, err := a.Test(newReq(t, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/access/%s", id, grantee.ID), "", r.editorToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestRevokeProjectAccess_NotFound(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	// No grant exists for this team.
+	resp, err := a.Test(newReq(t, http.MethodDelete, fmt.Sprintf("/v1/projects/%s/access/%s", id, uuid.NewString()), "", r.adminToken))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/internal/handler/project_test.go
+++ b/internal/handler/project_test.go
@@ -1,0 +1,245 @@
+package handler_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/px0-ai/px0/internal/store"
+)
+
+// projectRoles holds tokens for users at each capability level on a shared team,
+// plus an outsider who is a member of no team.
+type projectRoles struct {
+	adminToken    string
+	editorToken   string
+	viewerToken   string
+	outsiderToken string
+	teamID        string
+}
+
+// setupProjectRoles builds a team (via the admin from setupUser) with an editor,
+// a viewer, and an unrelated outsider, returning a token for each.
+func setupProjectRoles(t *testing.T, a *testApp) projectRoles {
+	t.Helper()
+	ctx := context.Background()
+
+	adminToken := setupUser(t, a)
+	adminSession, err := store.GetSessionByToken(ctx, adminToken)
+	require.NoError(t, err)
+
+	teams, err := store.GetUserTeams(ctx, adminSession.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, teams)
+	teamID := teams[0].ID
+
+	newMember := func(email, role string, join bool) string {
+		hash, err := bcrypt.GenerateFromPassword([]byte("Password123!"), bcrypt.DefaultCost)
+		require.NoError(t, err)
+		u, err := store.CreateVerifiedUser(ctx, email, string(hash))
+		require.NoError(t, err)
+		if join {
+			require.NoError(t, store.AddTeamMember(ctx, teamID, u.ID))
+			if role != "" {
+				require.NoError(t, store.UpdateTeamMemberRole(ctx, teamID, u.ID, role))
+			}
+		}
+		sess, err := store.CreateSession(ctx, u.ID, "sess_"+uuid.NewString(), adminSession.ExpiresAt)
+		require.NoError(t, err)
+		return sess.Token
+	}
+
+	return projectRoles{
+		adminToken:    adminToken,
+		editorToken:   newMember("proj-editor@px0.dev", "editor", true),
+		viewerToken:   newMember("proj-viewer@px0.dev", "viewer", true),
+		outsiderToken: newMember("proj-outsider@px0.dev", "", false),
+		teamID:        teamID.String(),
+	}
+}
+
+func createProjectBody(teamID, name string) string {
+	return fmt.Sprintf(`{"team_id":%q,"name":%q}`, teamID, name)
+}
+
+func TestCreateProject_Success(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodPost, "/v1/projects", createProjectBody(r.teamID, "Evals"), r.editorToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	project := decodeBody(t, resp)["project"].(map[string]any)
+	assert.NotEmpty(t, project["id"])
+	assert.Equal(t, r.teamID, project["owning_team_id"])
+	assert.Equal(t, "Evals", project["name"])
+	assert.Equal(t, "evals", project["slug"])
+}
+
+func TestCreateProject_ForbiddenForViewer(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodPost, "/v1/projects", createProjectBody(r.teamID, "Evals"), r.viewerToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestCreateProject_ForbiddenForNonMember(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodPost, "/v1/projects", createProjectBody(r.teamID, "Evals"), r.outsiderToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestCreateProject_MissingName(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodPost, "/v1/projects", fmt.Sprintf(`{"team_id":%q}`, r.teamID), r.editorToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestCreateProject_Duplicate(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodPost, "/v1/projects", createProjectBody(r.teamID, "Evals"), r.editorToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	resp.Body.Close()
+
+	req = newReq(t, http.MethodPost, "/v1/projects", createProjectBody(r.teamID, "Evals"), r.editorToken)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
+func TestCreateProject_Unauthorized(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodPost, "/v1/projects", createProjectBody(r.teamID, "Evals"), "")
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// createProject is a small helper that creates a project and returns its ID.
+func createProject(t *testing.T, a *testApp, token, teamID, name string) string {
+	t.Helper()
+	req := newReq(t, http.MethodPost, "/v1/projects", createProjectBody(teamID, name), token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	return decodeBody(t, resp)["project"].(map[string]any)["id"].(string)
+}
+
+func TestGetProject_Success(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	req := newReq(t, http.MethodGet, "/v1/projects/"+id, "", r.viewerToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, id, decodeBody(t, resp)["project"].(map[string]any)["id"])
+}
+
+func TestGetProject_NotFoundForNonMember(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	req := newReq(t, http.MethodGet, "/v1/projects/"+id, "", r.outsiderToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestGetProject_NotFound(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodGet, "/v1/projects/"+uuid.NewString(), "", r.editorToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestDeleteProject_Success(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	req := newReq(t, http.MethodDelete, "/v1/projects/"+id, "", r.adminToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Confirm it is gone.
+	_, err = store.GetProjectByID(context.Background(), uuid.MustParse(id))
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestDeleteProject_ForbiddenForNonAdmin(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	id := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	req := newReq(t, http.MethodDelete, "/v1/projects/"+id, "", r.editorToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestDeleteProject_NotFound(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodDelete, "/v1/projects/"+uuid.NewString(), "", r.adminToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestListTeamProjects_Success(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	createProject(t, a, r.editorToken, r.teamID, "Evals")
+	createProject(t, a, r.editorToken, r.teamID, "Prod")
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/projects", r.teamID), "", r.viewerToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	projects := decodeBody(t, resp)["projects"].([]any)
+	assert.Len(t, projects, 2)
+}
+
+func TestListTeamProjects_ForbiddenForNonMember(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/projects", r.teamID), "", r.outsiderToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}

--- a/internal/handler/prompt.go
+++ b/internal/handler/prompt.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 
 	"github.com/px0-ai/px0/internal/apierr"
-	"github.com/px0-ai/px0/internal/middleware"
 	"github.com/px0-ai/px0/internal/model"
 	"github.com/px0-ai/px0/internal/store"
 )
@@ -48,26 +47,38 @@ func NormalizeSlug(s string) string {
 	return res
 }
 
+// authorizeProject verifies the project is reachable by the requester at the
+// given capability (allowedIDs is the set of project IDs at that capability).
+// When it returns false it has already written a 404 (unknown project) or 403
+// (project exists but not accessible at this capability) response.
+func authorizeProject(c *fiber.Ctx, projectID uuid.UUID, allowedIDs []uuid.UUID) bool {
+	if containsUUID(allowedIDs, projectID) {
+		return true
+	}
+	if _, err := store.GetProjectByID(c.Context(), projectID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			_ = apierr.ErrProjectNotFound.Respond(c)
+		} else {
+			_ = apierr.ErrInternalError.Respond(c, err)
+		}
+		return false
+	}
+	_ = apierr.ErrForbidden.Respond(c)
+	return false
+}
+
 func CreatePrompt(c *fiber.Ctx) error {
-	teamID, err := uuid.Parse(c.Params("teamID"))
+	projectID, err := uuid.Parse(c.Params("projectID"))
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}
 
-	allowedIDs, err := getRequestEditorTeamIDs(c)
+	editorIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
-
-	isAllowed := false
-	for _, id := range allowedIDs {
-		if id == teamID {
-			isAllowed = true
-			break
-		}
-	}
-	if !isAllowed {
-		return apierr.ErrForbidden.Respond(c)
+	if !authorizeProject(c, projectID, editorIDs) {
+		return nil
 	}
 
 	var req createPromptRequest
@@ -85,7 +96,7 @@ func CreatePrompt(c *fiber.Ctx) error {
 	}
 	slug = NormalizeSlug(slug)
 
-	prompt, err := store.CreatePrompt(c.Context(), teamID, slug, req.Name, req.Description)
+	prompt, err := store.CreatePrompt(c.Context(), projectID, slug, req.Name, req.Description)
 	if err != nil {
 		if errors.Is(err, store.ErrDuplicate) {
 			return apierr.NewAPIError(fiber.StatusConflict, "prompt with this name or slug already exists; please provide a unique name").Respond(c)
@@ -96,25 +107,17 @@ func CreatePrompt(c *fiber.Ctx) error {
 }
 
 func ListPrompts(c *fiber.Ctx) error {
-	teamID, err := uuid.Parse(c.Params("teamID"))
+	projectID, err := uuid.Parse(c.Params("projectID"))
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}
 
-	allowedIDs, err := getRequestTeamIDs(c)
+	viewerIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
-
-	isAllowed := false
-	for _, id := range allowedIDs {
-		if id == teamID {
-			isAllowed = true
-			break
-		}
-	}
-	if !isAllowed {
-		return apierr.ErrForbidden.Respond(c)
+	if !authorizeProject(c, projectID, viewerIDs) {
+		return nil
 	}
 
 	var status *string
@@ -132,9 +135,9 @@ func ListPrompts(c *fiber.Ctx) error {
 	}
 
 	prompts, err := store.ListPrompts(c.Context(), store.PromptFilter{
-		TeamIDs:  []uuid.UUID{teamID},
-		Archived: archived,
-		Status:   status,
+		ProjectIDs: []uuid.UUID{projectID},
+		Archived:   archived,
+		Status:     status,
 	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
@@ -150,16 +153,16 @@ func GetPrompt(c *fiber.Ctx) error {
 	var prompt *model.Prompt
 	var err error
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
 	id, err := uuid.Parse(param)
 	if err == nil {
-		prompt, err = store.GetPromptByID(c.Context(), id, teamIDs)
+		prompt, err = store.GetPromptByID(c.Context(), id, projectIDs)
 	} else {
-		prompt, err = store.GetPromptBySlug(c.Context(), param, teamIDs)
+		prompt, err = store.GetPromptBySlug(c.Context(), param, projectIDs)
 	}
 
 	if err != nil {
@@ -206,31 +209,31 @@ func ArchivePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), id, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), id, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	adminTeamIDs, err := getRequestAdminTeamIDs(c)
+	adminProjectIDs, err := getRequestAdminProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if err := store.ArchivePrompt(c.Context(), id, adminTeamIDs); err != nil {
+	if err := store.ArchivePrompt(c.Context(), id, adminProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	prompt, err := store.GetPromptByID(c.Context(), id, teamIDs)
+	prompt, err := store.GetPromptByID(c.Context(), id, projectIDs)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -238,34 +241,26 @@ func ArchivePrompt(c *fiber.Ctx) error {
 }
 
 func ListAllPrompts(c *fiber.Ctx) error {
-	teamIDStr := c.Query("team")
-	if teamIDStr == "" {
-		teamIDStr = c.Query("team_id")
+	projectIDStr := c.Query("project")
+	if projectIDStr == "" {
+		projectIDStr = c.Query("project_id")
 	}
 
-	if teamIDStr == "" {
+	if projectIDStr == "" {
 		// By default nothing is shown as per backwards-compatible test requirements
 		return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
 	}
 
-	teamID, err := uuid.Parse(teamIDStr)
+	projectID, err := uuid.Parse(projectIDStr)
 	if err != nil {
 		return apierr.ErrInvalidID.Respond(c)
 	}
 
-	allowedIDs, err := getRequestTeamIDs(c)
+	allowedIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
-
-	isAllowed := false
-	for _, id := range allowedIDs {
-		if id == teamID {
-			isAllowed = true
-			break
-		}
-	}
-	if !isAllowed {
+	if !containsUUID(allowedIDs, projectID) {
 		return apierr.ErrForbidden.Respond(c)
 	}
 
@@ -284,9 +279,9 @@ func ListAllPrompts(c *fiber.Ctx) error {
 	}
 
 	prompts, err := store.ListPrompts(c.Context(), store.PromptFilter{
-		TeamIDs:  []uuid.UUID{teamID},
-		Archived: archived,
-		Status:   status,
+		ProjectIDs: []uuid.UUID{projectID},
+		Archived:   archived,
+		Status:     status,
 	})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
@@ -307,13 +302,13 @@ func UpdatePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	// First verify that the prompt exists and the user has basic team access
-	if _, err := store.GetPromptByID(c.Context(), id, teamIDs); err != nil {
+	// First verify that the prompt exists and the requester has read access
+	if _, err := store.GetPromptByID(c.Context(), id, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
@@ -321,7 +316,7 @@ func UpdatePrompt(c *fiber.Ctx) error {
 	}
 
 	// Verify editor permissions
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -331,7 +326,7 @@ func UpdatePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInvalidRequestBody.Respond(c)
 	}
 
-	prompt, err := store.UpdatePrompt(c.Context(), id, editorTeamIDs, req.Description)
+	prompt, err := store.UpdatePrompt(c.Context(), id, editorProjectIDs, req.Description)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
@@ -348,31 +343,31 @@ func RestorePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), id, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), id, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	adminTeamIDs, err := getRequestAdminTeamIDs(c)
+	adminProjectIDs, err := getRequestAdminProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if err := store.RestorePrompt(c.Context(), id, adminTeamIDs); err != nil {
+	if err := store.RestorePrompt(c.Context(), id, adminProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	prompt, err := store.GetPromptByID(c.Context(), id, teamIDs)
+	prompt, err := store.GetPromptByID(c.Context(), id, projectIDs)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -380,7 +375,7 @@ func RestorePrompt(c *fiber.Ctx) error {
 }
 
 type movePromptRequest struct {
-	TeamID string `json:"team_id"`
+	ProjectID string `json:"project_id"`
 }
 
 func MovePrompt(c *fiber.Ctx) error {
@@ -394,32 +389,17 @@ func MovePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInvalidRequestBody.Respond(c)
 	}
 
-	targetTeamID, err := uuid.Parse(req.TeamID)
+	targetProjectID, err := uuid.Parse(req.ProjectID)
 	if err != nil {
-		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid target team_id").Respond(c)
+		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid target project_id").Respond(c)
 	}
 
-	userID, ok := c.Locals(middleware.LocalsUserID).(uuid.UUID)
-	if !ok || userID == uuid.Nil {
-		return apierr.ErrUnauthorized.Respond(c)
-	}
-
-	// 1. Get the target team to find its OrgID
-	targetTeam, err := store.GetTeamByID(c.Context(), targetTeamID)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return apierr.NewAPIError(fiber.StatusNotFound, "target team not found").Respond(c)
-		}
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-
-	// 2. Fetch the prompt to find its current team (we check basic read access)
-	teamIDs, err := getRequestTeamIDs(c)
+	// Fetch the prompt to find its current project (basic read access first).
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
-
-	prompt, err := store.GetPromptByID(c.Context(), id, teamIDs)
+	prompt, err := store.GetPromptByID(c.Context(), id, projectIDs)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
@@ -427,64 +407,35 @@ func MovePrompt(c *fiber.Ctx) error {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	// Get current team details
-	currentTeam, err := store.GetTeamByID(c.Context(), prompt.TeamID)
+	// The target project must exist.
+	if _, err := store.GetProjectByID(c.Context(), targetProjectID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.NewAPIError(fiber.StatusNotFound, "target project not found").Respond(c)
+		}
+		return apierr.ErrInternalError.Respond(c, err)
+	}
+
+	// Require admin capability on BOTH the source and the target project.
+	adminProjectIDs, err := getRequestAdminProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
-
-	// 3. Verify Admin permission on BOTH current team and target team
-	currentTeamAdmin := false
-	if currentTeam.OrgID != nil {
-		isOrgAdmin, err := store.IsOrgAdmin(c.Context(), userID, *currentTeam.OrgID)
-		if err != nil {
-			return apierr.ErrInternalError.Respond(c, err)
-		}
-		if isOrgAdmin {
-			currentTeamAdmin = true
-		}
-	}
-	if !currentTeamAdmin {
-		isTeamAdmin, err := store.IsTeamAdmin(c.Context(), userID, currentTeam.ID)
-		if err != nil {
-			return apierr.ErrInternalError.Respond(c, err)
-		}
-		if isTeamAdmin {
-			currentTeamAdmin = true
-		}
-	}
-
-	targetTeamAdmin := false
-	if targetTeam.OrgID != nil {
-		isOrgAdmin, err := store.IsOrgAdmin(c.Context(), userID, *targetTeam.OrgID)
-		if err != nil {
-			return apierr.ErrInternalError.Respond(c, err)
-		}
-		if isOrgAdmin {
-			targetTeamAdmin = true
-		}
-	}
-	if !targetTeamAdmin {
-		isTeamAdmin, err := store.IsTeamAdmin(c.Context(), userID, targetTeam.ID)
-		if err != nil {
-			return apierr.ErrInternalError.Respond(c, err)
-		}
-		if isTeamAdmin {
-			targetTeamAdmin = true
-		}
-	}
-
-	if !currentTeamAdmin || !targetTeamAdmin {
+	if !containsUUID(adminProjectIDs, prompt.ProjectID) || !containsUUID(adminProjectIDs, targetProjectID) {
 		return apierr.ErrForbidden.Respond(c)
 	}
 
-	// Move the prompt
-	if err := store.MovePrompt(c.Context(), id, []uuid.UUID{currentTeam.ID}, targetTeamID); err != nil {
+	if err := store.MovePrompt(c.Context(), id, adminProjectIDs, targetProjectID); err != nil {
+		if errors.Is(err, store.ErrDuplicate) {
+			return apierr.NewAPIError(fiber.StatusConflict, "a prompt with this name or slug already exists in the target project").Respond(c)
+		}
+		if errors.Is(err, store.ErrNotFound) {
+			return apierr.ErrPromptNotFound.Respond(c)
+		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	// Retrieve updated prompt
-	prompt, err = store.GetPromptByID(c.Context(), id, []uuid.UUID{targetTeamID})
+	// Retrieve updated prompt from the target project.
+	prompt, err = store.GetPromptByID(c.Context(), id, []uuid.UUID{targetProjectID})
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
@@ -513,13 +464,13 @@ func DiffVersions(c *fiber.Ctx) error {
 		return apierr.NewAPIError(fiber.StatusBadRequest, "invalid to version").Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
 	// Verify read access to the prompt
-	if _, err := store.GetPromptByID(c.Context(), id, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), id, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}

--- a/internal/handler/prompt_test.go
+++ b/internal/handler/prompt_test.go
@@ -17,9 +17,9 @@ import (
 func TestCreatePrompt_Success(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"My Prompt","description":"Useful prompt"}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -30,16 +30,16 @@ func TestCreatePrompt_Success(t *testing.T) {
 	assert.NotEmpty(t, prompt["id"])
 	assert.Equal(t, "My Prompt", prompt["name"])
 	assert.Equal(t, "my_prompt", prompt["slug"])
-	assert.Equal(t, teamID, prompt["team_id"])
+	assert.Equal(t, projectID, prompt["project_id"])
 	assert.Equal(t, "Useful prompt", prompt["description"])
 }
 
 func TestCreatePrompt_CustomSlug(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"My Prompt","slug":"My-Custom_Slug!","description":"Useful prompt"}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -53,10 +53,9 @@ func TestCreatePrompt_CustomSlug(t *testing.T) {
 func TestCreatePrompt_Conflict(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
-	// Create first prompt
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"Unique Name","description":"desc"}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -64,7 +63,7 @@ func TestCreatePrompt_Conflict(t *testing.T) {
 	resp.Body.Close()
 
 	// 1. Conflict on name
-	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"Unique Name","description":"different"}`, token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
@@ -74,7 +73,7 @@ func TestCreatePrompt_Conflict(t *testing.T) {
 	resp.Body.Close()
 
 	// 2. Conflict on slug
-	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"Other Name","slug":"unique_name"}`, token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
@@ -87,9 +86,9 @@ func TestCreatePrompt_Conflict(t *testing.T) {
 func TestCreatePrompt_MissingName(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"description":"no name"}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -97,9 +96,34 @@ func TestCreatePrompt_MissingName(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestCreatePrompt_ForbiddenForViewer(t *testing.T) {
+	a := newTestApp(t)
+	r := setupProjectRoles(t, a)
+	projectID := createProject(t, a, r.editorToken, r.teamID, "Evals")
+
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
+		`{"name":"Blocked"}`, r.viewerToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestCreatePrompt_UnknownProject(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", uuid.New().String()),
+		`{"name":"Orphan"}`, token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+}
+
 func TestCreatePrompt_Unauthorized(t *testing.T) {
 	a := newTestApp(t)
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", uuid.New().String()),
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", uuid.New().String()),
 		`{"name":"p"}`, "")
 
 	resp, err := a.Test(req)
@@ -111,12 +135,12 @@ func TestCreatePrompt_Unauthorized(t *testing.T) {
 func TestListPrompts(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
-	setupPrompt(t, a, token)
-	setupPrompt(t, a, token)
+	setupPromptInProject(t, a, token, projectID)
+	setupPromptInProject(t, a, token, projectID)
 
-	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teamID), "", token)
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", projectID), "", token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -129,9 +153,9 @@ func TestListPrompts(t *testing.T) {
 func TestListPrompts_Empty(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
-	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teamID), "", token)
+	req := newReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", projectID), "", token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -164,7 +188,7 @@ func TestGetPrompt_BySlugAndVersion(t *testing.T) {
 
 	// Create a version and tag it
 	setupVersion(t, a, token, id, "Hello {{.name}}")
-	
+
 	// Set tag "prod" on Version 1
 	reqTag := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions/1/tags", id),
 		`{"tag":"prod"}`, token)
@@ -267,29 +291,30 @@ func TestPrompts_APIKeyAuth(t *testing.T) {
 	token := setupUser(t, a)
 	apiKey := setupAPIKey(t, a, token)
 
-	// API key works for listing prompts
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(apiKey)))
-	ctx := context.Background()
-	apiKeyModel, err := store.GetAPIKeyByHash(ctx, hash)
-	require.NoError(t, err)
-	teamID := apiKeyModel.TeamID.String()
+	// A project owned by the API key's team, reachable by the key.
+	projectID := setupProject(t, a, token)
 
-	req := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teamID), "", apiKey)
+	req := newAPIKeyReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", projectID), "", apiKey)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
+
+	// Sanity: the API key model is scoped to a team (unchanged).
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(apiKey)))
+	apiKeyModel, err := store.GetAPIKeyByHash(context.Background(), hash)
+	require.NoError(t, err)
+	assert.NotNil(t, apiKeyModel.TeamID)
 }
 
 func TestListAllPrompts(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
-	// Create a prompt
-	setupPrompt(t, a, token)
+	setupPromptInProject(t, a, token, projectID)
 
-	// 1. By default with no team_id, nothing is shown
+	// 1. By default with no project, nothing is shown
 	req := newReq(t, http.MethodGet, "/v1/prompts", "", token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -299,8 +324,8 @@ func TestListAllPrompts(t *testing.T) {
 	assert.Empty(t, prompts)
 	resp.Body.Close()
 
-	// 2. With allowed team_id query parameter, matching prompts are shown
-	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?team_id=%s", teamID), "", token)
+	// 2. With allowed project_id query parameter, matching prompts are shown
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?project_id=%s", projectID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -309,9 +334,9 @@ func TestListAllPrompts(t *testing.T) {
 	assert.Len(t, prompts, 1)
 	resp.Body.Close()
 
-	// 3. With unallowed team_id query parameter, 403 Forbidden is returned
-	unallowedTeamID := uuid.New().String()
-	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?team_id=%s", unallowedTeamID), "", token)
+	// 3. With unallowed project_id query parameter, 403 Forbidden is returned
+	unallowedProjectID := uuid.New().String()
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?project_id=%s", unallowedProjectID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
@@ -333,7 +358,6 @@ func TestArchivePrompt_Permissions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, teams)
 	teamID := teams[0].ID
-	teamIDStr := teamID.String()
 
 	// 2. Setup Editor User
 	editorUser, err := store.CreateVerifiedUser(ctx, "prompteditor@px0.dev", "Password123!")
@@ -359,9 +383,10 @@ func TestArchivePrompt_Permissions(t *testing.T) {
 	require.NoError(t, err)
 	viewerToken := viewerSession.Token
 
-	// 4. Create prompt as editor
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamIDStr),
-		`{"name":"Shared Prompt","description":"Prompt to test delete"}`, editorToken)
+	// A project owned by the team, plus a prompt created by the editor.
+	projectID := setupProject(t, a, adminToken)
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
+		`{"name":"Shared Prompt","description":"Prompt to test archive"}`, editorToken)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
@@ -369,21 +394,21 @@ func TestArchivePrompt_Permissions(t *testing.T) {
 	promptID := body["prompt"].(map[string]any)["id"].(string)
 	resp.Body.Close()
 
-	// 5. Viewer (Reader) cannot archive the prompt
+	// 5. Viewer cannot archive the prompt
 	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", promptID), "", viewerToken)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	resp.Body.Close()
 
-	// 6. Editor (Collaborator) cannot archive the prompt
+	// 6. Editor cannot archive the prompt
 	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", promptID), "", editorToken)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode) // Only Admins can archive prompts!
 	resp.Body.Close()
 
-	// 7. Admin (Owner) can archive the prompt
+	// 7. Admin can archive the prompt
 	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/archive", promptID), "", adminToken)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
@@ -397,10 +422,10 @@ func TestArchivePrompt_Permissions(t *testing.T) {
 func TestListAllPrompts_Filters(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	teamID := setupUserTeam(t, token)
+	projectID := setupProject(t, a, token)
 
 	// Create prompt A
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"Prompt Alpha","description":"First test prompt"}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -410,7 +435,7 @@ func TestListAllPrompts_Filters(t *testing.T) {
 	resp.Body.Close()
 
 	// Create prompt B
-	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamID),
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"Prompt Beta","description":"Second test prompt"}`, token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
@@ -441,8 +466,8 @@ func TestListAllPrompts_Filters(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	resp.Body.Close()
 
-	// Test 1: Query with team and archived=false
-	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?team=%s&archived=false", teamID), "", token)
+	// Test 1: Query with project and archived=false
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?project=%s&archived=false", projectID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -452,8 +477,8 @@ func TestListAllPrompts_Filters(t *testing.T) {
 	assert.Equal(t, pAID, prompts[0].(map[string]any)["id"].(string))
 	resp.Body.Close()
 
-	// Test 2: Query with team_id and archived=true
-	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?team_id=%s&archived=true", teamID), "", token)
+	// Test 2: Query with project_id and archived=true
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/prompts?project_id=%s&archived=true", projectID), "", token)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -473,7 +498,6 @@ func TestUpdatePrompt_Handler(t *testing.T) {
 	teamIDStr := setupUserTeam(t, adminToken)
 	teamID := uuid.MustParse(teamIDStr)
 
-	// Get admin session to match expiration
 	adminSession, err := store.GetSessionByToken(ctx, adminToken)
 	require.NoError(t, err)
 
@@ -501,8 +525,9 @@ func TestUpdatePrompt_Handler(t *testing.T) {
 	require.NoError(t, err)
 	viewerToken := viewerSession.Token
 
-	// 4. Create prompt as editor
-	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamIDStr),
+	// 4. Create project and prompt as editor
+	projectID := setupProject(t, a, adminToken)
+	req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
 		`{"name":"Shared Test Prompt","description":"Initial description"}`, editorToken)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -568,37 +593,47 @@ func TestRestorePrompt(t *testing.T) {
 func TestMovePrompt(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
 
-	// Let's create a new team under the user's organization.
-	reqOrgs := newReq(t, http.MethodGet, "/v1/me/orgs", "", token)
-	respOrgs, err := a.Test(reqOrgs)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, respOrgs.StatusCode)
-	bodyOrgs := decodeBody(t, respOrgs)
-	orgs := bodyOrgs["organizations"].([]any)
-	require.NotEmpty(t, orgs)
-	orgID := orgs[0].(map[string]any)["id"].(string)
-	respOrgs.Body.Close()
+	sourceProjectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, sourceProjectID)
+	targetProjectID := setupProject(t, a, token)
 
-	// Create a new target team under that org
-	reqTeam := newReq(t, http.MethodPost, fmt.Sprintf("/v1/orgs/%s/teams", orgID), `{"name":"Target Team"}`, token)
-	respTeam, err := a.Test(reqTeam)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusCreated, respTeam.StatusCode)
-	bodyTeam := decodeBody(t, respTeam)
-	targetTeamID := bodyTeam["team"].(map[string]any)["id"].(string)
-	respTeam.Body.Close()
-
-	// Move prompt to the target team
-	reqMove := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/move", id), fmt.Sprintf(`{"team_id":"%s"}`, targetTeamID), token)
+	reqMove := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/move", id),
+		fmt.Sprintf(`{"project_id":%q}`, targetProjectID), token)
 	respMove, err := a.Test(reqMove)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, respMove.StatusCode)
 	bodyMove := decodeBody(t, respMove)
 	pMove := bodyMove["prompt"].(map[string]any)
-	assert.Equal(t, targetTeamID, pMove["team_id"].(string))
+	assert.Equal(t, targetProjectID, pMove["project_id"].(string))
 	respMove.Body.Close()
+}
+
+func TestMovePrompt_TargetCollision(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	sourceProjectID := setupProject(t, a, token)
+	targetProjectID := setupProject(t, a, token)
+
+	// Same name/slug in both projects.
+	makePrompt := func(projectID string) string {
+		req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectID),
+			`{"name":"Greeting"}`, token)
+		resp, err := a.Test(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		return decodeBody(t, resp)["prompt"].(map[string]any)["id"].(string)
+	}
+	id := makePrompt(sourceProjectID)
+	makePrompt(targetProjectID)
+
+	reqMove := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/move", id),
+		fmt.Sprintf(`{"project_id":%q}`, targetProjectID), token)
+	resp, err := a.Test(reqMove)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	resp.Body.Close()
 }
 
 func TestDiffVersions(t *testing.T) {

--- a/internal/handler/render.go
+++ b/internal/handler/render.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
 	"github.com/px0-ai/px0/internal/apierr"
 	"github.com/px0-ai/px0/internal/model"
@@ -16,23 +17,56 @@ type renderRequest struct {
 	Variables map[string]any `json:"variables"`
 }
 
-func RenderLive(c *fiber.Ctx) error {
+// resolveProjectPromptBySlug loads the prompt identified by the :slug path
+// parameter within the :projectID project, enforcing that the requester can
+// reach that project. When it returns ok == false it has already written the
+// appropriate error response to c and the caller should return nil.
+func resolveProjectPromptBySlug(c *fiber.Ctx) (prompt *model.Prompt, ok bool) {
+	projectID, err := uuid.Parse(c.Params("projectID"))
+	if err != nil {
+		_ = apierr.ErrInvalidID.Respond(c)
+		return nil, false
+	}
 	slug := c.Params("slug")
 	if slug == "" {
-		return apierr.ErrPromptNotFound.Respond(c)
+		_ = apierr.ErrPromptNotFound.Respond(c)
+		return nil, false
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
+		_ = apierr.ErrInternalError.Respond(c, err)
+		return nil, false
 	}
 
-	prompt, err := store.GetPromptBySlug(c.Context(), slug, teamIDs)
+	accessible := false
+	for _, id := range projectIDs {
+		if id == projectID {
+			accessible = true
+			break
+		}
+	}
+	if !accessible {
+		_ = apierr.ErrPromptNotFound.Respond(c)
+		return nil, false
+	}
+
+	prompt, err = store.GetPromptBySlug(c.Context(), slug, []uuid.UUID{projectID})
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return apierr.ErrPromptNotFound.Respond(c)
+			_ = apierr.ErrPromptNotFound.Respond(c)
+		} else {
+			_ = apierr.ErrInternalError.Respond(c, err)
 		}
-		return apierr.ErrInternalError.Respond(c, err)
+		return nil, false
+	}
+	return prompt, true
+}
+
+func RenderLive(c *fiber.Ctx) error {
+	prompt, ok := resolveProjectPromptBySlug(c)
+	if !ok {
+		return nil
 	}
 
 	version, err := store.GetLiveVersion(c.Context(), prompt.ID)
@@ -47,22 +81,9 @@ func RenderLive(c *fiber.Ctx) error {
 }
 
 func RenderVersion(c *fiber.Ctx) error {
-	slug := c.Params("slug")
-	if slug == "" {
-		return apierr.ErrPromptNotFound.Respond(c)
-	}
-
-	teamIDs, err := getRequestTeamIDs(c)
-	if err != nil {
-		return apierr.ErrInternalError.Respond(c, err)
-	}
-
-	prompt, err := store.GetPromptBySlug(c.Context(), slug, teamIDs)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return apierr.ErrPromptNotFound.Respond(c)
-		}
-		return apierr.ErrInternalError.Respond(c, err)
+	prompt, ok := resolveProjectPromptBySlug(c)
+	if !ok {
+		return nil
 	}
 
 	version, err := resolveVersion(c.Context(), prompt.ID, c.Params("version"))

--- a/internal/handler/render_test.go
+++ b/internal/handler/render_test.go
@@ -19,26 +19,29 @@ func getPromptSlug(t *testing.T, a *testApp, id string, token string) string {
 	return body["prompt"].(map[string]any)["slug"].(string)
 }
 
+// promoteToLive promotes version 1 of the prompt from draft to live (draft ->
+// stable -> live) using two promote calls.
+func promoteToLive(t *testing.T, a *testApp, token, id string) {
+	t.Helper()
+	for i := 0; i < 2; i++ {
+		req := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
+		resp, err := a.Test(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+	}
+}
+
 func TestRenderLive_Success(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "Hello, {{.name}}! Count: {{.count}}.")
+	promoteToLive(t, a, token, id)
 
-	// promote version 1 to stable and then live
 	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, _ := a.Test(req)
-	resp.Body.Close()
-
-	req = newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, _ = a.Test(req)
-	resp.Body.Close()
-
-	req = newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/render", slug),
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/render", projectID, slug),
 		`{"variables":{"name":"Alice","count":5}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -52,12 +55,13 @@ func TestRenderLive_Success(t *testing.T) {
 func TestRenderLive_NoLiveVersion(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "draft only") // not published
 
 	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/render", slug),
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/render", projectID, slug),
 		`{"variables":{}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -68,22 +72,14 @@ func TestRenderLive_NoLiveVersion(t *testing.T) {
 func TestRenderLive_NoVariables(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "Static prompt with no variables.")
+	promoteToLive(t, a, token, id)
 
 	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, _ := a.Test(req)
-	resp.Body.Close()
-
-	req = newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, _ = a.Test(req)
-	resp.Body.Close()
-
-	req = newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/render", slug),
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/render", projectID, slug),
 		`{}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -96,26 +92,16 @@ func TestRenderLive_NoVariables(t *testing.T) {
 func TestRenderLive_MissingVariable(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "Hello, {{.name}}!")
+	promoteToLive(t, a, token, id)
 
 	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, err := a.Test(req)
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-
-	req = newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, err = a.Test(req)
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-
-	req = newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/render", slug),
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/render", projectID, slug),
 		`{"variables":{}}`, token)
-	resp, err = a.Test(req)
+	resp, err := a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 
@@ -167,12 +153,13 @@ func TestRenderLive_IncludesModelConfig(t *testing.T) {
 func TestRenderVersion_Draft(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "Draft: {{.msg}}")
 
 	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/render", slug),
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/versions/1/render", projectID, slug),
 		`{"variables":{"msg":"hello"}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -185,12 +172,13 @@ func TestRenderVersion_Draft(t *testing.T) {
 func TestRenderVersion_MissingVariable(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "Draft: {{.msg}}")
 
 	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/render", slug),
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/versions/1/render", projectID, slug),
 		`{"variables":{}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -205,11 +193,12 @@ func TestRenderVersion_MissingVariable(t *testing.T) {
 func TestRenderVersion_NotFound(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 
 	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/99/render", slug),
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/versions/99/render", projectID, slug),
 		`{"variables":{}}`, token)
 	resp, err := a.Test(req)
 	require.NoError(t, err)
@@ -221,23 +210,15 @@ func TestRenderLive_WithAPIKey(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
 	apiKey := setupAPIKey(t, a, token)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "Hi {{.user}}!")
-
-	req := newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, _ := a.Test(req)
-	resp.Body.Close()
-
-	req = newReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/versions/1/promote", id), "", token)
-	resp, _ = a.Test(req)
-	resp.Body.Close()
+	promoteToLive(t, a, token, id)
 
 	// render using API key (not session)
-	req = newAPIKeyReq(t, http.MethodPost,
-		fmt.Sprintf("/v1/prompts/%s/render", slug),
+	req := newAPIKeyReq(t, http.MethodPost,
+		fmt.Sprintf("/v1/projects/%s/prompts/%s/render", projectID, slug),
 		`{"variables":{"user":"Bob"}}`, apiKey)
 	resp, err := a.Test(req)
 	require.NoError(t, err)

--- a/internal/handler/roles_test.go
+++ b/internal/handler/roles_test.go
@@ -155,8 +155,13 @@ func TestRolesAndPermissions(t *testing.T) {
 	assert.True(t, foundViewer)
 
 	// 5. Test Permissions on Prompt Actions
+	// A project owned by the team; capability on its prompts is the team role.
+	promptProject, err := store.CreateProject(ctx, teamID, "roles_project", "Roles Project")
+	require.NoError(t, err)
+	projectIDStr := promptProject.ID.String()
+
 	// A. Editor can Create Prompt
-	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamIDStr), `{"name":"Editor Prompt","description":"Prompt by editor"}`, editorToken)
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectIDStr), `{"name":"Editor Prompt","description":"Prompt by editor"}`, editorToken)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
@@ -166,14 +171,14 @@ func TestRolesAndPermissions(t *testing.T) {
 	promptID, _ := uuid.Parse(promptIDStr)
 
 	// B. Viewer cannot Create Prompt
-	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/teams/%s/prompts", teamIDStr), `{"name":"Viewer Prompt","description":"Prompt by viewer"}`, viewerToken)
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts", projectIDStr), `{"name":"Viewer Prompt","description":"Prompt by viewer"}`, viewerToken)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	resp.Body.Close()
 
 	// C. Viewer can List Prompts
-	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/teams/%s/prompts", teamIDStr), "", viewerToken)
+	req = newReq(t, http.MethodGet, fmt.Sprintf("/v1/projects/%s/prompts", projectIDStr), "", viewerToken)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -233,7 +238,7 @@ func TestRolesAndPermissions(t *testing.T) {
 	resp.Body.Close()
 
 	// J. Viewer can Render Live
-	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/render", promptSlugStr), `{"variables":{"name":"John"}}`, viewerToken)
+	req = newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts/%s/render", projectIDStr, promptSlugStr), `{"variables":{"name":"John"}}`, viewerToken)
 	resp, err = a.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -277,7 +282,7 @@ func TestRolesAndPermissions(t *testing.T) {
 	resp.Body.Close()
 
 	// Verify prompt is archived
-	gotPrompt, err := store.GetPromptByID(ctx, promptID, []uuid.UUID{teamID})
+	gotPrompt, err := store.GetPromptByID(ctx, promptID, []uuid.UUID{promptProject.ID})
 	require.NoError(t, err)
 	assert.Equal(t, model.PromptStatusArchived, gotPrompt.Status)
 

--- a/internal/handler/tag.go
+++ b/internal/handler/tag.go
@@ -23,24 +23,24 @@ func SetTag(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -93,24 +93,24 @@ func RemoveTag(c *fiber.Ctx) error {
 		return apierr.ErrTagRequired.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -139,12 +139,12 @@ func ListTags(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}

--- a/internal/handler/tag_test.go
+++ b/internal/handler/tag_test.go
@@ -12,7 +12,8 @@ import (
 func TestTags_HandlerLifecycle(t *testing.T) {
 	a := newTestApp(t)
 	token := setupUser(t, a)
-	id := setupPrompt(t, a, token)
+	projectID := setupProject(t, a, token)
+	id := setupPromptInProject(t, a, token, projectID)
 	slug := getPromptSlug(t, a, id, token)
 	setupVersion(t, a, token, id, "Hello, {{.name}}!") // Creates Version 1
 
@@ -49,7 +50,7 @@ func TestTags_HandlerLifecycle(t *testing.T) {
 	assert.Contains(t, vGet["tags"].([]any), "prod")
 
 	// 4. Render version using tag "prod"
-	reqRenderByTag := newReq(t, http.MethodPost, fmt.Sprintf("/v1/prompts/%s/versions/prod/render", slug),
+	reqRenderByTag := newReq(t, http.MethodPost, fmt.Sprintf("/v1/projects/%s/prompts/%s/versions/prod/render", projectID, slug),
 		`{"variables":{"name":"Arpit"}}`, token)
 	respRenderByTag, err := a.Test(reqRenderByTag)
 	require.NoError(t, err)

--- a/internal/handler/version.go
+++ b/internal/handler/version.go
@@ -58,24 +58,24 @@ func CreateVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -118,12 +118,12 @@ func ListVersions(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
@@ -167,12 +167,12 @@ func GetVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
@@ -195,24 +195,24 @@ func UpdateVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -278,24 +278,24 @@ func PromoteVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -329,24 +329,24 @@ func DemoteVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -380,24 +380,24 @@ func ArchiveVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -431,24 +431,24 @@ func DeleteVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}
@@ -483,24 +483,24 @@ func DuplicateVersion(c *fiber.Ctx) error {
 		return apierr.ErrInvalidPromptID.Respond(c)
 	}
 
-	teamIDs, err := getRequestTeamIDs(c)
+	projectIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, teamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, projectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrPromptNotFound.Respond(c)
 		}
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	editorTeamIDs, err := getRequestEditorTeamIDs(c)
+	editorProjectIDs, err := getRequestEditorProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
 
-	if _, err := store.GetPromptByID(c.Context(), promptID, editorTeamIDs); err != nil {
+	if _, err := store.GetPromptByID(c.Context(), promptID, editorProjectIDs); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return apierr.ErrForbidden.Respond(c)
 		}

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Project is a named container for prompts owned by exactly one team.
+type Project struct {
+	ID           uuid.UUID `json:"id"`
+	OwningTeamID uuid.UUID `json:"owning_team_id"`
+	Name         string    `json:"name"`
+	Slug         string    `json:"slug"`
+	CreatedAt    time.Time `json:"created_at"`
+}

--- a/internal/model/prompt.go
+++ b/internal/model/prompt.go
@@ -14,7 +14,7 @@ const (
 
 type Prompt struct {
 	ID          uuid.UUID `json:"id"`
-	TeamID      uuid.UUID `json:"team_id"`
+	ProjectID   uuid.UUID `json:"project_id"`
 	Slug        string    `json:"slug"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`

--- a/internal/store/migration_test.go
+++ b/internal/store/migration_test.go
@@ -1,0 +1,97 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/px0-ai/px0/internal/db"
+	"github.com/px0-ai/px0/internal/store"
+	"github.com/px0-ai/px0/internal/testutil"
+)
+
+// TestMigration021_BackfillDefaultProjects validates the core backfill algorithm
+// from migration 021 (internal/db/migrations/021_prompts_to_projects.sql): every
+// team that owns at least one prompt gets exactly one default project with its
+// prompts moved in, and teams with no prompts get none.
+//
+// It reconstructs the pre-migration shape — prompts referencing a team, not yet
+// a project — in a temporary table and runs the same one-project-per-team logic
+// against the real teams/projects tables, then asserts the backfilled state.
+func TestMigration021_BackfillDefaultProjects(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+
+	withPrompts, err := store.CreateTeam(ctx, "Team With Prompts")
+	require.NoError(t, err)
+	withoutPrompts, err := store.CreateTeam(ctx, "Team Without Prompts")
+	require.NoError(t, err)
+
+	tx, err := db.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	_, err = tx.Exec(ctx, `CREATE TEMP TABLE legacy_prompts (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		team_id UUID NOT NULL,
+		name TEXT NOT NULL,
+		slug TEXT NOT NULL,
+		project_id UUID
+	) ON COMMIT DROP`)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx,
+		`INSERT INTO legacy_prompts (team_id, name, slug) VALUES ($1, 'A', 'a'), ($1, 'B', 'b')`,
+		withPrompts.ID)
+	require.NoError(t, err)
+
+	// Backfill logic mirroring migration 021.
+	_, err = tx.Exec(ctx, `DO $$
+	DECLARE
+		t RECORD;
+		new_project_id UUID;
+	BEGIN
+		FOR t IN
+			SELECT tm.id AS team_id, tm.name AS team_name
+			FROM teams tm
+			WHERE EXISTS (SELECT 1 FROM legacy_prompts p WHERE p.team_id = tm.id)
+		LOOP
+			INSERT INTO projects (owning_team_id, name, slug)
+			VALUES (
+				t.team_id,
+				t.team_name || ' Default Project',
+				COALESCE(NULLIF(trim(both '_' from regexp_replace(lower(t.team_name || ' default project'), '[^a-z0-9_]+', '_', 'g')), ''), 'default_project')
+			)
+			RETURNING id INTO new_project_id;
+			UPDATE legacy_prompts SET project_id = new_project_id WHERE team_id = t.team_id;
+		END LOOP;
+	END $$`)
+	require.NoError(t, err)
+
+	// Team with prompts: exactly one project was created.
+	var withProjectCount int
+	require.NoError(t, tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM projects WHERE owning_team_id = $1`, withPrompts.ID).Scan(&withProjectCount))
+	assert.Equal(t, 1, withProjectCount)
+
+	// Both of its prompts were reassigned to that project; none left unassigned.
+	var unassigned int
+	require.NoError(t, tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM legacy_prompts WHERE project_id IS NULL`).Scan(&unassigned))
+	assert.Equal(t, 0, unassigned)
+
+	var assignedToTeamProject int
+	require.NoError(t, tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM legacy_prompts lp
+		 JOIN projects pr ON pr.id = lp.project_id
+		 WHERE pr.owning_team_id = $1`, withPrompts.ID).Scan(&assignedToTeamProject))
+	assert.Equal(t, 2, assignedToTeamProject)
+
+	// Team without prompts: no project created.
+	var withoutProjectCount int
+	require.NoError(t, tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM projects WHERE owning_team_id = $1`, withoutPrompts.ID).Scan(&withoutProjectCount))
+	assert.Equal(t, 0, withoutProjectCount)
+}

--- a/internal/store/payload_test.go
+++ b/internal/store/payload_test.go
@@ -16,10 +16,9 @@ func TestPromptPayloadCRUD(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
 
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	p, err := store.CreatePrompt(ctx, tm.ID, "greeting", "Greeting", "A greeting prompt")
+	p, err := store.CreatePrompt(ctx, proj.ID, "greeting", "Greeting", "A greeting prompt")
 	require.NoError(t, err)
 
 	// 1. Create Payload

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -76,6 +76,42 @@ func ListProjectsForTeam(ctx context.Context, teamID uuid.UUID) ([]*model.Projec
 	return projects, rows.Err()
 }
 
+// GrantProjectAccess records that teamID may work with the project's prompts.
+// It is idempotent (re-granting is a no-op) and returns ErrNotFound if the
+// project or team does not exist.
+func GrantProjectAccess(ctx context.Context, projectID, teamID uuid.UUID) error {
+	_, err := db.Pool.Exec(ctx,
+		`INSERT INTO project_team_access (project_id, team_id)
+		 VALUES ($1, $2)
+		 ON CONFLICT DO NOTHING`,
+		projectID, teamID,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return ErrNotFound
+		}
+		return fmt.Errorf("grant project access: %w", err)
+	}
+	return nil
+}
+
+// RevokeProjectAccess removes a team's access grant. Returns ErrNotFound if no
+// such grant existed.
+func RevokeProjectAccess(ctx context.Context, projectID, teamID uuid.UUID) error {
+	result, err := db.Pool.Exec(ctx,
+		`DELETE FROM project_team_access WHERE project_id = $1 AND team_id = $2`,
+		projectID, teamID,
+	)
+	if err != nil {
+		return fmt.Errorf("revoke project access: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // IsProjectAccessibleByTeams reports whether the project is reachable by any of
 // the given teams — either as the owning team or via an access grant.
 func IsProjectAccessibleByTeams(ctx context.Context, projectID uuid.UUID, teamIDs []uuid.UUID) (bool, error) {

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -76,6 +76,35 @@ func ListProjectsForTeam(ctx context.Context, teamID uuid.UUID) ([]*model.Projec
 	return projects, rows.Err()
 }
 
+// ListAccessibleProjectIDs returns the IDs of all projects reachable by the
+// given teams — those the teams own plus those granted to them. This is the
+// single expansion point from a requester's teams to the projects (and thus
+// prompts) they can reach; the capability the requester holds is determined by
+// which team-role set (viewer/editor/admin) the team IDs were drawn from.
+func ListAccessibleProjectIDs(ctx context.Context, teamIDs []uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := db.Pool.Query(ctx,
+		`SELECT DISTINCT p.id
+		 FROM projects p
+		 LEFT JOIN project_team_access pta ON pta.project_id = p.id
+		 WHERE p.owning_team_id = ANY($1) OR pta.team_id = ANY($1)`,
+		teamIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list accessible project ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // GrantProjectAccess records that teamID may work with the project's prompts.
 // It is idempotent (re-granting is a no-op) and returns ErrNotFound if the
 // project or team does not exist.

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/px0-ai/px0/internal/db"
+	"github.com/px0-ai/px0/internal/model"
+)
+
+// CreateProject inserts a project owned by owningTeamID. A colliding name or
+// slug within the same owning team returns ErrDuplicate.
+func CreateProject(ctx context.Context, owningTeamID uuid.UUID, slug, name string) (*model.Project, error) {
+	p := &model.Project{}
+	err := db.Pool.QueryRow(ctx,
+		`INSERT INTO projects (owning_team_id, slug, name)
+		 VALUES ($1, $2, $3)
+		 RETURNING id, owning_team_id, slug, name, created_at`,
+		owningTeamID, slug, name,
+	).Scan(&p.ID, &p.OwningTeamID, &p.Slug, &p.Name, &p.CreatedAt)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, ErrDuplicate
+		}
+		return nil, fmt.Errorf("create project: %w", err)
+	}
+	return p, nil
+}
+
+// GetProjectByID returns the project with the given id, or ErrNotFound.
+func GetProjectByID(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	p := &model.Project{}
+	err := db.Pool.QueryRow(ctx,
+		`SELECT id, owning_team_id, slug, name, created_at FROM projects WHERE id = $1`,
+		id,
+	).Scan(&p.ID, &p.OwningTeamID, &p.Slug, &p.Name, &p.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get project by id: %w", err)
+	}
+	return p, nil
+}
+
+// ListProjectsForTeam returns the projects a team owns plus those granted to it,
+// most recent first.
+func ListProjectsForTeam(ctx context.Context, teamID uuid.UUID) ([]*model.Project, error) {
+	rows, err := db.Pool.Query(ctx,
+		`SELECT DISTINCT p.id, p.owning_team_id, p.slug, p.name, p.created_at
+		 FROM projects p
+		 LEFT JOIN project_team_access pta ON pta.project_id = p.id
+		 WHERE p.owning_team_id = $1 OR pta.team_id = $1
+		 ORDER BY p.created_at DESC`,
+		teamID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list projects for team: %w", err)
+	}
+	defer rows.Close()
+
+	var projects []*model.Project
+	for rows.Next() {
+		p := &model.Project{}
+		if err := rows.Scan(&p.ID, &p.OwningTeamID, &p.Slug, &p.Name, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		projects = append(projects, p)
+	}
+	return projects, rows.Err()
+}
+
+// IsProjectAccessibleByTeams reports whether the project is reachable by any of
+// the given teams — either as the owning team or via an access grant.
+func IsProjectAccessibleByTeams(ctx context.Context, projectID uuid.UUID, teamIDs []uuid.UUID) (bool, error) {
+	var accessible bool
+	err := db.Pool.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM projects p
+			LEFT JOIN project_team_access pta ON pta.project_id = p.id
+			WHERE p.id = $1 AND (p.owning_team_id = ANY($2) OR pta.team_id = ANY($2))
+		)`,
+		projectID, teamIDs,
+	).Scan(&accessible)
+	if err != nil {
+		return false, fmt.Errorf("check project accessible by teams: %w", err)
+	}
+	return accessible, nil
+}
+
+// DeleteProject hard-deletes a project, cascading to its prompts and grants.
+// Returns ErrNotFound if no project matched.
+func DeleteProject(ctx context.Context, id uuid.UUID) error {
+	result, err := db.Pool.Exec(ctx, `DELETE FROM projects WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete project: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/store/project_test.go
+++ b/internal/store/project_test.go
@@ -97,6 +97,64 @@ func TestListProjectsForTeam(t *testing.T) {
 	assert.Empty(t, projects)
 }
 
+func TestListAccessibleProjectIDs(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+
+	owner, err := store.CreateTeam(ctx, "Owner Team")
+	require.NoError(t, err)
+	grantee, err := store.CreateTeam(ctx, "Grantee Team")
+	require.NoError(t, err)
+	stranger, err := store.CreateTeam(ctx, "Stranger Team")
+	require.NoError(t, err)
+
+	owned, err := store.CreateProject(ctx, owner.ID, "owned", "Owned")
+	require.NoError(t, err)
+	shared, err := store.CreateProject(ctx, owner.ID, "shared", "Shared")
+	require.NoError(t, err)
+	require.NoError(t, store.GrantProjectAccess(ctx, shared.ID, grantee.ID))
+
+	idSet := func(ids []uuid.UUID) map[uuid.UUID]bool {
+		m := make(map[uuid.UUID]bool, len(ids))
+		for _, id := range ids {
+			m[id] = true
+		}
+		return m
+	}
+
+	// Owned-only: the owner reaches both its projects (owned + one it also shares).
+	ids, err := store.ListAccessibleProjectIDs(ctx, []uuid.UUID{owner.ID})
+	require.NoError(t, err)
+	set := idSet(ids)
+	assert.Len(t, ids, 2)
+	assert.True(t, set[owned.ID])
+	assert.True(t, set[shared.ID])
+
+	// Granted-only: the grantee reaches only the shared project.
+	ids, err = store.ListAccessibleProjectIDs(ctx, []uuid.UUID{grantee.ID})
+	require.NoError(t, err)
+	assert.Equal(t, []uuid.UUID{shared.ID}, ids)
+
+	// Both: a requester in both owner and grantee teams reaches both projects
+	// with no duplicates.
+	ids, err = store.ListAccessibleProjectIDs(ctx, []uuid.UUID{owner.ID, grantee.ID})
+	require.NoError(t, err)
+	set = idSet(ids)
+	assert.Len(t, ids, 2)
+	assert.True(t, set[owned.ID])
+	assert.True(t, set[shared.ID])
+
+	// None: a team that neither owns nor is granted anything reaches nothing.
+	ids, err = store.ListAccessibleProjectIDs(ctx, []uuid.UUID{stranger.ID})
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+
+	// Empty team set reaches nothing.
+	ids, err = store.ListAccessibleProjectIDs(ctx, []uuid.UUID{})
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 func TestGrantProjectAccess(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()

--- a/internal/store/project_test.go
+++ b/internal/store/project_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -94,6 +95,78 @@ func TestListProjectsForTeam(t *testing.T) {
 	projects, err = store.ListProjectsForTeam(ctx, empty.ID)
 	require.NoError(t, err)
 	assert.Empty(t, projects)
+}
+
+func TestGrantProjectAccess(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	owner, err := store.CreateTeam(ctx, "Owner Team")
+	require.NoError(t, err)
+	grantee, err := store.CreateTeam(ctx, "Grantee Team")
+	require.NoError(t, err)
+	project, err := store.CreateProject(ctx, owner.ID, "shared", "Shared")
+	require.NoError(t, err)
+
+	require.NoError(t, store.GrantProjectAccess(ctx, project.ID, grantee.ID))
+
+	// Re-granting is a no-op, not an error.
+	require.NoError(t, store.GrantProjectAccess(ctx, project.ID, grantee.ID))
+
+	accessible, err := store.IsProjectAccessibleByTeams(ctx, project.ID, []uuid.UUID{grantee.ID})
+	require.NoError(t, err)
+	assert.True(t, accessible)
+
+	// The grantee now sees the project in its list.
+	projects, err := store.ListProjectsForTeam(ctx, grantee.ID)
+	require.NoError(t, err)
+	assert.Len(t, projects, 1)
+}
+
+func TestGrantProjectAccess_UnknownProjectOrTeam(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	owner, err := store.CreateTeam(ctx, "Owner Team")
+	require.NoError(t, err)
+	project, err := store.CreateProject(ctx, owner.ID, "shared", "Shared")
+	require.NoError(t, err)
+
+	err = store.GrantProjectAccess(ctx, nonExistentUUID(), owner.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	err = store.GrantProjectAccess(ctx, project.ID, nonExistentUUID())
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestRevokeProjectAccess(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	owner, err := store.CreateTeam(ctx, "Owner Team")
+	require.NoError(t, err)
+	grantee, err := store.CreateTeam(ctx, "Grantee Team")
+	require.NoError(t, err)
+	project, err := store.CreateProject(ctx, owner.ID, "shared", "Shared")
+	require.NoError(t, err)
+
+	require.NoError(t, store.GrantProjectAccess(ctx, project.ID, grantee.ID))
+	require.NoError(t, store.RevokeProjectAccess(ctx, project.ID, grantee.ID))
+
+	accessible, err := store.IsProjectAccessibleByTeams(ctx, project.ID, []uuid.UUID{grantee.ID})
+	require.NoError(t, err)
+	assert.False(t, accessible)
+}
+
+func TestRevokeProjectAccess_NotFound(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	owner, err := store.CreateTeam(ctx, "Owner Team")
+	require.NoError(t, err)
+	grantee, err := store.CreateTeam(ctx, "Grantee Team")
+	require.NoError(t, err)
+	project, err := store.CreateProject(ctx, owner.ID, "shared", "Shared")
+	require.NoError(t, err)
+
+	err = store.RevokeProjectAccess(ctx, project.ID, grantee.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
 }
 
 func TestDeleteProject(t *testing.T) {

--- a/internal/store/project_test.go
+++ b/internal/store/project_test.go
@@ -1,0 +1,134 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/px0-ai/px0/internal/store"
+	"github.com/px0-ai/px0/internal/testutil"
+)
+
+func TestCreateProject(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	p, err := store.CreateProject(ctx, tm.ID, "evals", "Evals")
+	require.NoError(t, err)
+	assert.NotEmpty(t, p.ID)
+	assert.Equal(t, tm.ID, p.OwningTeamID)
+	assert.Equal(t, "evals", p.Slug)
+	assert.Equal(t, "Evals", p.Name)
+	assert.NotZero(t, p.CreatedAt)
+}
+
+func TestCreateProject_Duplicate(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	_, err = store.CreateProject(ctx, tm.ID, "evals", "Evals")
+	require.NoError(t, err)
+
+	// Duplicate name within the same owning team.
+	_, err = store.CreateProject(ctx, tm.ID, "other_slug", "Evals")
+	assert.ErrorIs(t, err, store.ErrDuplicate)
+
+	// Duplicate slug within the same owning team.
+	_, err = store.CreateProject(ctx, tm.ID, "evals", "Other Name")
+	assert.ErrorIs(t, err, store.ErrDuplicate)
+
+	// Same name/slug under a different owning team is allowed.
+	other, err := store.CreateTeam(ctx, "Other Team")
+	require.NoError(t, err)
+	_, err = store.CreateProject(ctx, other.ID, "evals", "Evals")
+	require.NoError(t, err)
+}
+
+func TestGetProjectByID(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	created, err := store.CreateProject(ctx, tm.ID, "find_me", "Find Me")
+	require.NoError(t, err)
+
+	got, err := store.GetProjectByID(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, tm.ID, got.OwningTeamID)
+	assert.Equal(t, "find_me", got.Slug)
+}
+
+func TestGetProjectByID_NotFound(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	_, err := store.GetProjectByID(ctx, nonExistentUUID())
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestListProjectsForTeam(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Owner Team")
+	require.NoError(t, err)
+
+	_, err = store.CreateProject(ctx, tm.ID, "proj_a", "Proj A")
+	require.NoError(t, err)
+	_, err = store.CreateProject(ctx, tm.ID, "proj_b", "Proj B")
+	require.NoError(t, err)
+
+	projects, err := store.ListProjectsForTeam(ctx, tm.ID)
+	require.NoError(t, err)
+	assert.Len(t, projects, 2)
+
+	// A team owning nothing sees an empty list.
+	empty, err := store.CreateTeam(ctx, "Empty Team")
+	require.NoError(t, err)
+	projects, err = store.ListProjectsForTeam(ctx, empty.ID)
+	require.NoError(t, err)
+	assert.Empty(t, projects)
+}
+
+func TestDeleteProject(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Test Team")
+	require.NoError(t, err)
+
+	p, err := store.CreateProject(ctx, tm.ID, "delete_me", "Delete Me")
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeleteProject(ctx, p.ID))
+
+	_, err = store.GetProjectByID(ctx, p.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestDeleteProject_NotFound(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	err := store.DeleteProject(ctx, nonExistentUUID())
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestDeleteTeam_CascadesProjects(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	tm, err := store.CreateTeam(ctx, "Doomed Team")
+	require.NoError(t, err)
+
+	p, err := store.CreateProject(ctx, tm.ID, "orphan", "Orphan")
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeleteTeam(ctx, tm.ID))
+
+	_, err = store.GetProjectByID(ctx, p.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/internal/store/prompt.go
+++ b/internal/store/prompt.go
@@ -15,20 +15,20 @@ import (
 )
 
 type PromptFilter struct {
-	TeamIDs  []uuid.UUID
-	Tags     []string
-	Archived *bool
-	Status   *string
+	ProjectIDs []uuid.UUID
+	Tags       []string
+	Archived   *bool
+	Status     *string
 }
 
-func CreatePrompt(ctx context.Context, teamID uuid.UUID, slug, name, description string) (*model.Prompt, error) {
+func CreatePrompt(ctx context.Context, projectID uuid.UUID, slug, name, description string) (*model.Prompt, error) {
 	p := &model.Prompt{}
 	err := db.Pool.QueryRow(ctx,
-		`INSERT INTO prompts (team_id, slug, name, description)
+		`INSERT INTO prompts (project_id, slug, name, description)
 		 VALUES ($1, $2, $3, $4)
-		 RETURNING id, team_id, slug, name, description, status, created_at, updated_at`,
-		teamID, slug, name, description,
-	).Scan(&p.ID, &p.TeamID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
+		 RETURNING id, project_id, slug, name, description, status, created_at, updated_at`,
+		projectID, slug, name, description,
+	).Scan(&p.ID, &p.ProjectID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -40,7 +40,7 @@ func CreatePrompt(ctx context.Context, teamID uuid.UUID, slug, name, description
 }
 
 func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, error) {
-	query := `SELECT DISTINCT p.id, p.team_id, p.slug, p.name, p.description, p.status, p.created_at, p.updated_at
+	query := `SELECT DISTINCT p.id, p.project_id, p.slug, p.name, p.description, p.status, p.created_at, p.updated_at
 			  FROM prompts p`
 	args := []any{}
 	joins := ""
@@ -52,9 +52,9 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 		whereClauses = append(whereClauses, fmt.Sprintf("pt.tag = ANY($%d)", len(args)))
 	}
 
-	if len(filter.TeamIDs) > 0 {
-		args = append(args, filter.TeamIDs)
-		whereClauses = append(whereClauses, fmt.Sprintf("p.team_id = ANY($%d)", len(args)))
+	if len(filter.ProjectIDs) > 0 {
+		args = append(args, filter.ProjectIDs)
+		whereClauses = append(whereClauses, fmt.Sprintf("p.project_id = ANY($%d)", len(args)))
 	}
 
 	if filter.Status != nil {
@@ -84,7 +84,7 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 	var prompts []*model.Prompt
 	for rows.Next() {
 		p := &model.Prompt{}
-		if err := rows.Scan(&p.ID, &p.TeamID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.ProjectID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt); err != nil {
 			return nil, err
 		}
 		prompts = append(prompts, p)
@@ -92,14 +92,14 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 	return prompts, rows.Err()
 }
 
-func GetPromptByID(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) (*model.Prompt, error) {
+func GetPromptByID(ctx context.Context, id uuid.UUID, projectIDs []uuid.UUID) (*model.Prompt, error) {
 	p := &model.Prompt{}
 	err := db.Pool.QueryRow(ctx,
-		`SELECT id, team_id, slug, name, description, status, created_at, updated_at
+		`SELECT id, project_id, slug, name, description, status, created_at, updated_at
 		 FROM prompts
-		 WHERE id = $1 AND team_id = ANY($2)`,
-		id, teamIDs,
-	).Scan(&p.ID, &p.TeamID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
+		 WHERE id = $1 AND project_id = ANY($2)`,
+		id, projectIDs,
+	).Scan(&p.ID, &p.ProjectID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -109,14 +109,14 @@ func GetPromptByID(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) (*mod
 	return p, nil
 }
 
-func GetPromptBySlug(ctx context.Context, slug string, teamIDs []uuid.UUID) (*model.Prompt, error) {
+func GetPromptBySlug(ctx context.Context, slug string, projectIDs []uuid.UUID) (*model.Prompt, error) {
 	p := &model.Prompt{}
 	err := db.Pool.QueryRow(ctx,
-		`SELECT id, team_id, slug, name, description, status, created_at, updated_at
+		`SELECT id, project_id, slug, name, description, status, created_at, updated_at
 		 FROM prompts
-		 WHERE slug = $1 AND team_id = ANY($2)`,
-		slug, teamIDs,
-	).Scan(&p.ID, &p.TeamID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
+		 WHERE slug = $1 AND project_id = ANY($2)`,
+		slug, projectIDs,
+	).Scan(&p.ID, &p.ProjectID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -126,9 +126,9 @@ func GetPromptBySlug(ctx context.Context, slug string, teamIDs []uuid.UUID) (*mo
 	return p, nil
 }
 
-func ArchivePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) error {
-	// First check if the prompt belongs to one of the provided teams
-	_, err := GetPromptByID(ctx, id, teamIDs)
+func ArchivePrompt(ctx context.Context, id uuid.UUID, projectIDs []uuid.UUID) error {
+	// First check if the prompt belongs to one of the provided projects
+	_, err := GetPromptByID(ctx, id, projectIDs)
 	if err != nil {
 		return err // ErrNotFound if not found or no access
 	}
@@ -143,9 +143,9 @@ func ArchivePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) error
 	return nil
 }
 
-func UpdatePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID, description string) (*model.Prompt, error) {
-	// First check if the prompt belongs to one of the allowed teams
-	_, err := GetPromptByID(ctx, id, teamIDs)
+func UpdatePrompt(ctx context.Context, id uuid.UUID, projectIDs []uuid.UUID, description string) (*model.Prompt, error) {
+	// First check if the prompt belongs to one of the allowed projects
+	_, err := GetPromptByID(ctx, id, projectIDs)
 	if err != nil {
 		return nil, err // ErrNotFound if not found or no access
 	}
@@ -155,9 +155,9 @@ func UpdatePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID, descri
 		`UPDATE prompts
 		 SET description = $1, updated_at = NOW()
 		 WHERE id = $2
-		 RETURNING id, team_id, slug, name, description, status, created_at, updated_at`,
+		 RETURNING id, project_id, slug, name, description, status, created_at, updated_at`,
 		description, id,
-	).Scan(&p.ID, &p.TeamID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
+	).Scan(&p.ID, &p.ProjectID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -167,8 +167,8 @@ func UpdatePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID, descri
 	return p, nil
 }
 
-func RestorePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) error {
-	_, err := GetPromptByID(ctx, id, teamIDs)
+func RestorePrompt(ctx context.Context, id uuid.UUID, projectIDs []uuid.UUID) error {
+	_, err := GetPromptByID(ctx, id, projectIDs)
 	if err != nil {
 		return err // ErrNotFound if not found or no access
 	}
@@ -183,14 +183,22 @@ func RestorePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID) error
 	return nil
 }
 
-func MovePrompt(ctx context.Context, id uuid.UUID, teamIDs []uuid.UUID, targetTeamID uuid.UUID) error {
-	_, err := GetPromptByID(ctx, id, teamIDs)
+// MovePrompt relocates a prompt to the target project. The caller must have
+// already authorized the move; projectIDs scopes which projects the prompt may
+// currently belong to. A name or slug collision in the target project is
+// rejected with ErrDuplicate.
+func MovePrompt(ctx context.Context, id uuid.UUID, projectIDs []uuid.UUID, targetProjectID uuid.UUID) error {
+	_, err := GetPromptByID(ctx, id, projectIDs)
 	if err != nil {
 		return err // ErrNotFound if not found or no access
 	}
 
-	_, err = db.Pool.Exec(ctx, "UPDATE prompts SET team_id = $1, updated_at = NOW() WHERE id = $2", targetTeamID, id)
+	_, err = db.Pool.Exec(ctx, "UPDATE prompts SET project_id = $1, updated_at = NOW() WHERE id = $2", targetProjectID, id)
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrDuplicate
+		}
 		return fmt.Errorf("move prompt: %w", err)
 	}
 	return nil

--- a/internal/store/prompt_test.go
+++ b/internal/store/prompt_test.go
@@ -13,16 +13,25 @@ import (
 	"github.com/px0-ai/px0/internal/testutil"
 )
 
+// newProject creates a team and a project owned by it, returning the project.
+func newProject(t *testing.T, ctx context.Context, name string) *model.Project {
+	t.Helper()
+	tm, err := store.CreateTeam(ctx, name+" Team")
+	require.NoError(t, err)
+	proj, err := store.CreateProject(ctx, tm.ID, "default", name+" Project")
+	require.NoError(t, err)
+	return proj
+}
+
 func TestCreatePrompt(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	p, err := store.CreatePrompt(ctx, tm.ID, "greeting", "Greeting", "A greeting prompt")
+	p, err := store.CreatePrompt(ctx, proj.ID, "greeting", "Greeting", "A greeting prompt")
 	require.NoError(t, err)
 	assert.NotEmpty(t, p.ID)
-	assert.Equal(t, tm.ID, p.TeamID)
+	assert.Equal(t, proj.ID, p.ProjectID)
 	assert.Equal(t, "greeting", p.Slug)
 	assert.Equal(t, "Greeting", p.Name)
 	assert.Equal(t, "A greeting prompt", p.Description)
@@ -32,32 +41,35 @@ func TestCreatePrompt(t *testing.T) {
 func TestCreatePrompt_Duplicate(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
+	proj := newProject(t, ctx, "Test")
+
+	_, err := store.CreatePrompt(ctx, proj.ID, "greeting", "Greeting", "A greeting prompt")
 	require.NoError(t, err)
 
-	_, err = store.CreatePrompt(ctx, tm.ID, "greeting", "Greeting", "A greeting prompt")
+	// Duplicate slug/name within the same project should return ErrDuplicate.
+	_, err = store.CreatePrompt(ctx, proj.ID, "greeting", "Other Name", "Another greeting")
+	assert.ErrorIs(t, err, store.ErrDuplicate)
+
+	_, err = store.CreatePrompt(ctx, proj.ID, "other_slug", "Greeting", "Another greeting")
+	assert.ErrorIs(t, err, store.ErrDuplicate)
+
+	// The same name/slug under a different project is allowed.
+	other := newProject(t, ctx, "Other")
+	_, err = store.CreatePrompt(ctx, other.ID, "greeting", "Greeting", "A greeting prompt")
 	require.NoError(t, err)
-
-	// Duplicate slug/name should return ErrDuplicate
-	_, err = store.CreatePrompt(ctx, tm.ID, "greeting", "Other Name", "Another greeting")
-	assert.ErrorIs(t, err, store.ErrDuplicate)
-
-	_, err = store.CreatePrompt(ctx, tm.ID, "other_slug", "Greeting", "Another greeting")
-	assert.ErrorIs(t, err, store.ErrDuplicate)
 }
 
 func TestListPrompts(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
+	proj := newProject(t, ctx, "Test")
+
+	_, err := store.CreatePrompt(ctx, proj.ID, "prompt_a", "Prompt A", "")
+	require.NoError(t, err)
+	_, err = store.CreatePrompt(ctx, proj.ID, "prompt_b", "Prompt B", "")
 	require.NoError(t, err)
 
-	_, err = store.CreatePrompt(ctx, tm.ID, "prompt_a", "Prompt A", "")
-	require.NoError(t, err)
-	_, err = store.CreatePrompt(ctx, tm.ID, "prompt_b", "Prompt B", "")
-	require.NoError(t, err)
-
-	prompts, err := store.ListPrompts(ctx, store.PromptFilter{TeamIDs: []uuid.UUID{tm.ID}})
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{ProjectIDs: []uuid.UUID{proj.ID}})
 	require.NoError(t, err)
 	assert.Len(t, prompts, 2)
 }
@@ -65,10 +77,9 @@ func TestListPrompts(t *testing.T) {
 func TestListPrompts_Empty(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	prompts, err := store.ListPrompts(ctx, store.PromptFilter{TeamIDs: []uuid.UUID{tm.ID}})
+	prompts, err := store.ListPrompts(ctx, store.PromptFilter{ProjectIDs: []uuid.UUID{proj.ID}})
 	require.NoError(t, err)
 	assert.Empty(t, prompts)
 }
@@ -76,16 +87,15 @@ func TestListPrompts_Empty(t *testing.T) {
 func TestGetPromptByID(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
+	proj := newProject(t, ctx, "Test")
+
+	created, err := store.CreatePrompt(ctx, proj.ID, "find_me", "Find Me", "desc")
 	require.NoError(t, err)
 
-	created, err := store.CreatePrompt(ctx, tm.ID, "find_me", "Find Me", "desc")
-	require.NoError(t, err)
-
-	got, err := store.GetPromptByID(ctx, created.ID, []uuid.UUID{tm.ID})
+	got, err := store.GetPromptByID(ctx, created.ID, []uuid.UUID{proj.ID})
 	require.NoError(t, err)
 	assert.Equal(t, created.ID, got.ID)
-	assert.Equal(t, tm.ID, got.TeamID)
+	assert.Equal(t, proj.ID, got.ProjectID)
 	assert.Equal(t, "find_me", got.Slug)
 	assert.Equal(t, "Find Me", got.Name)
 }
@@ -93,26 +103,24 @@ func TestGetPromptByID(t *testing.T) {
 func TestGetPromptByID_NotFound(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	_, err = store.GetPromptByID(ctx, nonExistentUUID(), []uuid.UUID{tm.ID})
+	_, err := store.GetPromptByID(ctx, nonExistentUUID(), []uuid.UUID{proj.ID})
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
 
 func TestGetPromptBySlug(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
+	proj := newProject(t, ctx, "Test")
+
+	created, err := store.CreatePrompt(ctx, proj.ID, "find_me_slug", "Find Me Slug", "desc")
 	require.NoError(t, err)
 
-	created, err := store.CreatePrompt(ctx, tm.ID, "find_me_slug", "Find Me Slug", "desc")
-	require.NoError(t, err)
-
-	got, err := store.GetPromptBySlug(ctx, "find_me_slug", []uuid.UUID{tm.ID})
+	got, err := store.GetPromptBySlug(ctx, "find_me_slug", []uuid.UUID{proj.ID})
 	require.NoError(t, err)
 	assert.Equal(t, created.ID, got.ID)
-	assert.Equal(t, tm.ID, got.TeamID)
+	assert.Equal(t, proj.ID, got.ProjectID)
 	assert.Equal(t, "find_me_slug", got.Slug)
 	assert.Equal(t, "Find Me Slug", got.Name)
 }
@@ -120,27 +128,25 @@ func TestGetPromptBySlug(t *testing.T) {
 func TestGetPromptBySlug_NotFound(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	_, err = store.GetPromptBySlug(ctx, "nonexistent", []uuid.UUID{tm.ID})
+	_, err := store.GetPromptBySlug(ctx, "nonexistent", []uuid.UUID{proj.ID})
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
 
 func TestArchivePrompt(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	p, err := store.CreatePrompt(ctx, tm.ID, "archive_me", "Archive Me", "")
+	p, err := store.CreatePrompt(ctx, proj.ID, "archive_me", "Archive Me", "")
 	require.NoError(t, err)
 	assert.Equal(t, model.PromptStatusActive, p.Status)
 
-	err = store.ArchivePrompt(ctx, p.ID, []uuid.UUID{tm.ID})
+	err = store.ArchivePrompt(ctx, p.ID, []uuid.UUID{proj.ID})
 	require.NoError(t, err)
 
-	got, err := store.GetPromptByID(ctx, p.ID, []uuid.UUID{tm.ID})
+	got, err := store.GetPromptByID(ctx, p.ID, []uuid.UUID{proj.ID})
 	require.NoError(t, err)
 	assert.Equal(t, model.PromptStatusArchived, got.Status)
 }
@@ -148,33 +154,31 @@ func TestArchivePrompt(t *testing.T) {
 func TestArchivePrompt_NotFound(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	err = store.ArchivePrompt(ctx, nonExistentUUID(), []uuid.UUID{tm.ID})
+	err := store.ArchivePrompt(ctx, nonExistentUUID(), []uuid.UUID{proj.ID})
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
 
 func TestListPrompts_Filters(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	pA, err := store.CreatePrompt(ctx, tm.ID, "prompt_a", "Prompt A", "")
+	pA, err := store.CreatePrompt(ctx, proj.ID, "prompt_a", "Prompt A", "")
 	require.NoError(t, err)
-	pB, err := store.CreatePrompt(ctx, tm.ID, "prompt_b", "Prompt B", "")
+	pB, err := store.CreatePrompt(ctx, proj.ID, "prompt_b", "Prompt B", "")
 	require.NoError(t, err)
 
 	// 1. Archive pB
-	err = store.ArchivePrompt(ctx, pB.ID, []uuid.UUID{tm.ID})
+	err = store.ArchivePrompt(ctx, pB.ID, []uuid.UUID{proj.ID})
 	require.NoError(t, err)
 
 	// Test Archived = false (Active only)
 	activeOnly := false
 	prompts, err := store.ListPrompts(ctx, store.PromptFilter{
-		TeamIDs:  []uuid.UUID{tm.ID},
-		Archived: &activeOnly,
+		ProjectIDs: []uuid.UUID{proj.ID},
+		Archived:   &activeOnly,
 	})
 	require.NoError(t, err)
 	assert.Len(t, prompts, 1)
@@ -183,8 +187,8 @@ func TestListPrompts_Filters(t *testing.T) {
 	// Test Archived = true (Archived only)
 	archivedOnly := true
 	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
-		TeamIDs:  []uuid.UUID{tm.ID},
-		Archived: &archivedOnly,
+		ProjectIDs: []uuid.UUID{proj.ID},
+		Archived:   &archivedOnly,
 	})
 	require.NoError(t, err)
 	assert.Len(t, prompts, 1)
@@ -198,8 +202,8 @@ func TestListPrompts_Filters(t *testing.T) {
 
 	// Filter by tag "prod"
 	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
-		TeamIDs: []uuid.UUID{tm.ID},
-		Tags:    []string{"prod"},
+		ProjectIDs: []uuid.UUID{proj.ID},
+		Tags:       []string{"prod"},
 	})
 	require.NoError(t, err)
 	assert.Len(t, prompts, 1)
@@ -207,8 +211,8 @@ func TestListPrompts_Filters(t *testing.T) {
 
 	// Filter by non-existent tag
 	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
-		TeamIDs: []uuid.UUID{tm.ID},
-		Tags:    []string{"nonexistent_tag"},
+		ProjectIDs: []uuid.UUID{proj.ID},
+		Tags:       []string{"nonexistent_tag"},
 	})
 	require.NoError(t, err)
 	assert.Empty(t, prompts)
@@ -216,8 +220,8 @@ func TestListPrompts_Filters(t *testing.T) {
 	// Filter by Status = "active"
 	activeStatus := model.PromptStatusActive
 	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
-		TeamIDs: []uuid.UUID{tm.ID},
-		Status:  &activeStatus,
+		ProjectIDs: []uuid.UUID{proj.ID},
+		Status:     &activeStatus,
 	})
 	require.NoError(t, err)
 	assert.Len(t, prompts, 1)
@@ -226,8 +230,8 @@ func TestListPrompts_Filters(t *testing.T) {
 	// Filter by Status = "archived"
 	archivedStatus := model.PromptStatusArchived
 	prompts, err = store.ListPrompts(ctx, store.PromptFilter{
-		TeamIDs: []uuid.UUID{tm.ID},
-		Status:  &archivedStatus,
+		ProjectIDs: []uuid.UUID{proj.ID},
+		Status:     &archivedStatus,
 	})
 	require.NoError(t, err)
 	assert.Len(t, prompts, 1)
@@ -237,26 +241,76 @@ func TestListPrompts_Filters(t *testing.T) {
 func TestUpdatePrompt(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
+	proj := newProject(t, ctx, "Test")
 
-	p, err := store.CreatePrompt(ctx, tm.ID, "my_prompt", "My Prompt", "Initial description")
+	p, err := store.CreatePrompt(ctx, proj.ID, "my_prompt", "My Prompt", "Initial description")
 	require.NoError(t, err)
 
 	// 1. Success update
-	updated, err := store.UpdatePrompt(ctx, p.ID, []uuid.UUID{tm.ID}, "Updated description")
+	updated, err := store.UpdatePrompt(ctx, p.ID, []uuid.UUID{proj.ID}, "Updated description")
 	require.NoError(t, err)
 	assert.Equal(t, p.ID, updated.ID)
 	assert.Equal(t, "my_prompt", updated.Slug) // slug remains unchanged
 	assert.Equal(t, "My Prompt", updated.Name) // name remains unchanged
 	assert.Equal(t, "Updated description", updated.Description)
 
-	// 2. Not found / Unauthorized team update
-	otherTeam, err := store.CreateTeam(ctx, "Other Team")
-	require.NoError(t, err)
-	_, err = store.UpdatePrompt(ctx, p.ID, []uuid.UUID{otherTeam.ID}, "Updated description")
+	// 2. Not found / Unauthorized project update
+	otherProject := newProject(t, ctx, "Other")
+	_, err = store.UpdatePrompt(ctx, p.ID, []uuid.UUID{otherProject.ID}, "Updated description")
 	assert.ErrorIs(t, err, store.ErrNotFound)
 
-	_, err = store.UpdatePrompt(ctx, nonExistentUUID(), []uuid.UUID{tm.ID}, "Updated description")
+	_, err = store.UpdatePrompt(ctx, nonExistentUUID(), []uuid.UUID{proj.ID}, "Updated description")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMovePrompt(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	source := newProject(t, ctx, "Source")
+	target := newProject(t, ctx, "Target")
+
+	p, err := store.CreatePrompt(ctx, source.ID, "movable", "Movable", "")
+	require.NoError(t, err)
+
+	// Success: move into the target project.
+	err = store.MovePrompt(ctx, p.ID, []uuid.UUID{source.ID}, target.ID)
+	require.NoError(t, err)
+
+	moved, err := store.GetPromptByID(ctx, p.ID, []uuid.UUID{target.ID})
+	require.NoError(t, err)
+	assert.Equal(t, target.ID, moved.ProjectID)
+
+	// It no longer belongs to the source project.
+	_, err = store.GetPromptByID(ctx, p.ID, []uuid.UUID{source.ID})
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMovePrompt_TargetCollision(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	source := newProject(t, ctx, "Source")
+	target := newProject(t, ctx, "Target")
+
+	p, err := store.CreatePrompt(ctx, source.ID, "greeting", "Greeting", "")
+	require.NoError(t, err)
+	// Target already has a prompt with the same name/slug.
+	_, err = store.CreatePrompt(ctx, target.ID, "greeting", "Greeting", "")
+	require.NoError(t, err)
+
+	err = store.MovePrompt(ctx, p.ID, []uuid.UUID{source.ID}, target.ID)
+	assert.ErrorIs(t, err, store.ErrDuplicate)
+}
+
+func TestDeleteProject_CascadesPrompts(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	proj := newProject(t, ctx, "Doomed")
+
+	p, err := store.CreatePrompt(ctx, proj.ID, "doomed_prompt", "Doomed Prompt", "")
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeleteProject(ctx, proj.ID))
+
+	_, err = store.GetPromptByID(ctx, p.ID, []uuid.UUID{proj.ID})
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }

--- a/internal/store/version_test.go
+++ b/internal/store/version_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func newPrompt(t *testing.T, ctx context.Context) *model.Prompt {
-	tm, err := store.CreateTeam(ctx, "Test Team")
-	require.NoError(t, err)
-	p, err := store.CreatePrompt(ctx, tm.ID, "my-prompt", "My Prompt", "Desc")
+	proj := newProject(t, ctx, "Test")
+	p, err := store.CreatePrompt(ctx, proj.ID, "my-prompt", "My Prompt", "Desc")
 	require.NoError(t, err)
 	return p
 }


### PR DESCRIPTION
## What & why

Closes #12.

Prompts belong directly to a **team** today, so everything a team owns is visible to the same people, and two teams can't share a subset of prompts without merging teams or copying prompts around.

This PR introduces a **Project**: a named container for prompts that sits between team and prompt. A project is owned by one team and can grant access to other teams **in the same org**. What a user can *do* with a project's prompts is still their team role (viewer/editor/admin) — the grant only opens the door.

## Breaking change

`prompt.team_id` → `prompt.project_id`, and create/list routes move from `/teams/:teamID/prompts` to `/projects/:projectID/prompts`. Migration `021` backfills existing data (one default project per prompt-owning team) — no manual steps.

## What changed

- **Project entity** — `projects` + `project_team_access` tables, model, store CRUD, and create/get/delete/list routes. Name/slug unique per owning team.
- **Access grants** — grant/revoke another team's access; owning-team (or org) admin only, same-org only.
- **Access resolver** — a requester's teams expand to reachable projects (owned + granted); higher role wins on overlap.
- **Prompt cutover** — prompts live under projects; by-ID routes keep their URLs but authorize via the project.
- **Move between projects** — `POST /prompts/:id/move` requires admin on source and target, rejects a target name/slug collision (409).
- **API-key reach** — a key's teams expand to their accessible projects, so keys reach shared projects too.

## Testing

Store and handler tests cover CRUD, permission boundaries (401/403/404/409), migration backfill invariants, move + collision, cascade deletes, and API-key reach. `make check` is green (`go test -race`, `go vet`, `gofmt`). OpenAPI specs under `docs/openapi/` are the source of truth; every route is contract-checked in the handler tests.

## Reviewer notes

- **The migration is destructive** — it drops `prompts.team_id` and adds a NOT NULL FK. Backfills automatically, but please review `internal/db/migrations/021_prompts_to_projects.sql` closely.
- **Render is POST, not GET.** The issue says `GET .../render`, but render takes a `variables` body, so it's POST to match the existing render handlers. Easy to switch.
- **Granting to the owning team returns 400** ("already has implicit access") to keep the owning team from ever being a grant row.
