### PR TITLE
Add hybrid prompt search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,30 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # User Verification & Admin Access
 RESEND_API_KEY=your_resend_api_key_here
 RESEND_FROM_EMAIL=onboarding@resend.dev
+
+# Prompt search
+# The API always accepts natural-language text through GET /v1/prompts?q=...
+# and combines results from the configured FTS and vector retrieval slots.
+SEARCH_FTS_PROVIDER=postgres
+SEARCH_VECTOR_PROVIDER=none
+
+# Elasticsearch / OpenSearch (provider implementations reserved)
+# ELASTICSEARCH_URL=http://localhost:9200
+# ELASTICSEARCH_API_KEY=
+# ELASTICSEARCH_INDEX=px0_prompts
+# OPENSEARCH_URL=http://localhost:9200
+# OPENSEARCH_USERNAME=
+# OPENSEARCH_PASSWORD=
+# OPENSEARCH_INDEX=px0_prompts
+
+# Algolia (provider implementation reserved)
+# ALGOLIA_APP_ID=
+# ALGOLIA_API_KEY=
+# ALGOLIA_INDEX_NAME=px0_prompts
+
+# Qdrant / Pinecone (provider implementations reserved)
+# QDRANT_URL=http://localhost:6333
+# QDRANT_API_KEY=
+# QDRANT_COLLECTION=px0_prompts
+# PINECONE_API_KEY=
+# PINECONE_INDEX=px0-prompts

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/px0-ai/px0/internal/app"
 	"github.com/px0-ai/px0/internal/db"
 	"github.com/px0-ai/px0/internal/rdb"
+	"github.com/px0-ai/px0/internal/search"
 	"github.com/px0-ai/px0/internal/telemetry"
 )
 
@@ -41,10 +42,15 @@ func main() {
 	}
 	defer rdb.Close()
 
+	promptSearch, err := search.NewFromEnv()
+	if err != nil {
+		log.Fatalf("configure prompt search: %v", err)
+	}
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8000"
 	}
 
-	log.Fatal(app.New().Listen(":" + port))
+	log.Fatal(app.NewWithSearch(promptSearch).Listen(":" + port))
 }

--- a/docs/openapi/openapi-bundled.yaml
+++ b/docs/openapi/openapi-bundled.yaml
@@ -2199,8 +2199,8 @@ paths:
                 error: internal error
   /v1/prompts:
     get:
-      summary: List all prompts with project filter
-      description: Returns a list of prompts. If the project_id query parameter is not provided, returns an empty list by default. Users can filter by a project they can reach.
+      summary: List or Search Prompts
+      description: Returns prompts from projects the requester can reach. Supplying q performs hybrid search from one natural-language query; the server retrieves lexical and semantic candidates, reranks them, and returns only authorized prompts. Without q, the existing project-filtered listing behavior is preserved.
       operationId: listAllPrompts
       tags:
         - Prompts
@@ -2227,13 +2227,34 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+        - name: q
+          in: query
+          required: false
+          description: Natural-language search text. The server—not the client—handles lexical retrieval, semantic retrieval, and reranking. Raw vectors and provider selection are never accepted by the API.
+          schema:
+            type: string
+            minLength: 1
+            example: Find a prompt that handles customer refunds
       x-edge-cases:
-        - By default with no project_id query parameter, returns an empty list of prompts.
+        - With neither q nor project_id, returns an empty list to preserve existing behavior.
         - If a project_id is provided, checks the requester can reach that project, otherwise returns 403 Forbidden.
+        - A q search without project_id spans every project the requester can view, including projects granted to the requester's teams.
+        - A q search with project_id is restricted to that authorized project.
+        - An empty or whitespace-only q returns 400 instead of running an unbounded search.
+        - Search defaults to active prompts; archived=true searches archived prompts instead.
+        - Search results never include prompts from inaccessible projects, even if a retriever returns their IDs.
+        - Provider-specific scores, modes, and vectors are internal and are not exposed in the request or response.
       x-test-coverage:
         - 'TestListAllPrompts: Verifies that no project_id returns 200 with an empty list.'
         - 'TestListAllPrompts: Verifies that a valid project_id returns 200 with prompts of that project.'
         - 'TestListAllPrompts: Verifies that an unallowed project_id returns 403 Forbidden.'
+        - 'TestSearchPromptsAcrossAccessibleProjects: Verifies natural-language search spans accessible projects, preserves relevance order, and excludes an inaccessible project.'
+        - 'TestSearchPromptsRejectsEmptyQuery: Verifies whitespace-only q returns 400.'
+        - 'TestSearchPromptsExcludesArchivedByDefault: Verifies archived prompts are excluded by default and searchable only with archived=true.'
+        - 'TestAPIKey_ReachesGrantedProject: Verifies API-key search includes prompts from granted projects and stops returning them immediately after access is revoked.'
+        - 'TestPostgresRetrieverSearchesFieldsAndEnforcesScope: Verifies weighted FTS across prompt fields and project isolation.'
+        - 'TestPostgresRetrieverReflectsPromptUpdates: Verifies the generated FTS document tracks prompt updates without a separate indexing job.'
+        - 'TestEngineSearchRetrievesAndReranksBothSources: Verifies lexical and semantic candidates are both retrieved and deterministically fused.'
       responses:
         '200':
           description: A list of prompts
@@ -2246,6 +2267,14 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Prompt'
+        '400':
+          description: Invalid or empty search query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                error: q query parameter must not be empty
         '401':
           description: Unauthorized
           content:

--- a/docs/openapi/prompts.yaml
+++ b/docs/openapi/prompts.yaml
@@ -168,8 +168,8 @@ paths:
 
   /v1/prompts:
     get:
-      summary: List all prompts with project filter
-      description: Returns a list of prompts. If the project_id query parameter is not provided, returns an empty list by default. Users can filter by a project they can reach.
+      summary: List or Search Prompts
+      description: Returns prompts from projects the requester can reach. Supplying q performs hybrid search from one natural-language query; the server retrieves lexical and semantic candidates, reranks them, and returns only authorized prompts. Without q, the existing project-filtered listing behavior is preserved.
       operationId: listAllPrompts
       tags:
         - Prompts
@@ -196,13 +196,34 @@ paths:
           description: Optional boolean to filter prompts by archive state.
           schema:
             type: boolean
+        - name: q
+          in: query
+          required: false
+          description: Natural-language search text. The server—not the client—handles lexical retrieval, semantic retrieval, and reranking. Raw vectors and provider selection are never accepted by the API.
+          schema:
+            type: string
+            minLength: 1
+            example: Find a prompt that handles customer refunds
       x-edge-cases:
-        - "By default with no project_id query parameter, returns an empty list of prompts."
+        - "With neither q nor project_id, returns an empty list to preserve existing behavior."
         - "If a project_id is provided, checks the requester can reach that project, otherwise returns 403 Forbidden."
+        - "A q search without project_id spans every project the requester can view, including projects granted to the requester's teams."
+        - "A q search with project_id is restricted to that authorized project."
+        - "An empty or whitespace-only q returns 400 instead of running an unbounded search."
+        - "Search defaults to active prompts; archived=true searches archived prompts instead."
+        - "Search results never include prompts from inaccessible projects, even if a retriever returns their IDs."
+        - "Provider-specific scores, modes, and vectors are internal and are not exposed in the request or response."
       x-test-coverage:
         - "TestListAllPrompts: Verifies that no project_id returns 200 with an empty list."
         - "TestListAllPrompts: Verifies that a valid project_id returns 200 with prompts of that project."
         - "TestListAllPrompts: Verifies that an unallowed project_id returns 403 Forbidden."
+        - "TestSearchPromptsAcrossAccessibleProjects: Verifies natural-language search spans accessible projects, preserves relevance order, and excludes an inaccessible project."
+        - "TestSearchPromptsRejectsEmptyQuery: Verifies whitespace-only q returns 400."
+        - "TestSearchPromptsExcludesArchivedByDefault: Verifies archived prompts are excluded by default and searchable only with archived=true."
+        - "TestAPIKey_ReachesGrantedProject: Verifies API-key search includes prompts from granted projects and stops returning them immediately after access is revoked."
+        - "TestPostgresRetrieverSearchesFieldsAndEnforcesScope: Verifies weighted FTS across prompt fields and project isolation."
+        - "TestPostgresRetrieverReflectsPromptUpdates: Verifies the generated FTS document tracks prompt updates without a separate indexing job."
+        - "TestEngineSearchRetrievesAndReranksBothSources: Verifies lexical and semantic candidates are both retrieved and deterministically fused."
       responses:
         "200":
           description: A list of prompts
@@ -221,6 +242,14 @@ paths:
             application/json:
               schema:
                 $ref: "./auth.yaml#/components/schemas/APIError"
+        "400":
+          description: Invalid or empty search query
+          content:
+            application/json:
+              schema:
+                $ref: "./auth.yaml#/components/schemas/APIError"
+              example:
+                error: "q query parameter must not be empty"
         "403":
           description: Forbidden
           content:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,9 +8,17 @@ import (
 	"github.com/px0-ai/px0/internal/handler"
 	"github.com/px0-ai/px0/internal/middleware"
 	"github.com/px0-ai/px0/internal/model"
+	"github.com/px0-ai/px0/internal/search"
 )
 
 func New() *fiber.App {
+	return NewWithSearch(search.NewDefault())
+}
+
+func NewWithSearch(promptSearch search.Searcher) *fiber.App {
+	if promptSearch == nil {
+		promptSearch = search.NewDefault()
+	}
 	app := fiber.New(fiber.Config{AppName: "px0"})
 
 	app.Use(cors.New(cors.Config{
@@ -90,7 +98,7 @@ func New() *fiber.App {
 	apiKeys.Delete("/:id", handler.DeleteAPIKey)
 
 	prompts := v1.Group("/prompts", middleware.RequireAuth)
-	prompts.Get("", handler.ListAllPrompts)
+	prompts.Get("", handler.ListAllPrompts(promptSearch))
 	prompts.Get("/:id", handler.GetPrompt)
 	prompts.Put("/:id", handler.UpdatePrompt)
 	prompts.Post("/:id/archive", handler.ArchivePrompt)

--- a/internal/db/migrations/024_prompt_search.sql
+++ b/internal/db/migrations/024_prompt_search.sql
@@ -1,0 +1,10 @@
+ALTER TABLE prompts
+    ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+        setweight(to_tsvector('english', coalesce(slug, '')), 'C')
+    ) STORED;
+
+CREATE INDEX idx_prompts_search_vector
+    ON prompts USING GIN (search_vector);

--- a/internal/handler/apikey_projects_test.go
+++ b/internal/handler/apikey_projects_test.go
@@ -72,9 +72,24 @@ func TestAPIKey_ReachesGrantedProject(t *testing.T) {
 	prompts := decodeBody(t, resp)["prompts"].([]any)
 	assert.Len(t, prompts, 1)
 
+	// Search uses the same expanded project scope and never requires clients
+	// to submit provider-specific vectors or modes.
+	searchReq := newAPIKeyReq(t, http.MethodGet, "/v1/prompts?q=greeting", "", apiKey)
+	searchResp, err := a.Test(searchReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, searchResp.StatusCode)
+	searchResults := decodeBody(t, searchResp)["prompts"].([]any)
+	assert.Len(t, searchResults, 1)
+
 	// 3. After revoking the grant, reach is lost again.
 	require.NoError(t, store.RevokeProjectAccess(ctx, project.ID, granteeTeam.ID))
 	assert.Equal(t, http.StatusForbidden, listWithKey())
+	searchReq = newAPIKeyReq(t, http.MethodGet, "/v1/prompts?q=greeting", "", apiKey)
+	searchResp, err = a.Test(searchReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, searchResp.StatusCode)
+	searchResults = decodeBody(t, searchResp)["prompts"].([]any)
+	assert.Empty(t, searchResults)
 }
 
 // TestAPIKey_DeniedForeignProject verifies an API key cannot reach a project

--- a/internal/handler/prompt.go
+++ b/internal/handler/prompt.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/px0-ai/px0/internal/apierr"
 	"github.com/px0-ai/px0/internal/model"
+	"github.com/px0-ai/px0/internal/search"
 	"github.com/px0-ai/px0/internal/store"
 )
 
@@ -240,28 +241,44 @@ func ArchivePrompt(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"prompt": prompt})
 }
 
-func ListAllPrompts(c *fiber.Ctx) error {
+func ListAllPrompts(searcher search.Searcher) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		return listAllPrompts(c, searcher)
+	}
+}
+
+func listAllPrompts(c *fiber.Ctx, searcher search.Searcher) error {
 	projectIDStr := c.Query("project")
 	if projectIDStr == "" {
 		projectIDStr = c.Query("project_id")
 	}
 
-	if projectIDStr == "" {
-		// By default nothing is shown as per backwards-compatible test requirements
-		return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
+	queryProvided := c.Context().QueryArgs().Has("q")
+	query := strings.TrimSpace(c.Query("q"))
+	if queryProvided && query == "" {
+		return apierr.NewAPIError(fiber.StatusBadRequest, "q query parameter must not be empty").Respond(c)
 	}
 
-	projectID, err := uuid.Parse(projectIDStr)
-	if err != nil {
-		return apierr.ErrInvalidID.Respond(c)
+	if projectIDStr == "" && !queryProvided {
+		// By default nothing is shown as per backwards-compatible test requirements
+		return c.JSON(fiber.Map{"prompts": []*model.Prompt{}})
 	}
 
 	allowedIDs, err := getRequestViewerProjectIDs(c)
 	if err != nil {
 		return apierr.ErrInternalError.Respond(c, err)
 	}
-	if !containsUUID(allowedIDs, projectID) {
-		return apierr.ErrForbidden.Respond(c)
+
+	projectIDs := allowedIDs
+	if projectIDStr != "" {
+		projectID, err := uuid.Parse(projectIDStr)
+		if err != nil {
+			return apierr.ErrInvalidID.Respond(c)
+		}
+		if !containsUUID(allowedIDs, projectID) {
+			return apierr.ErrForbidden.Respond(c)
+		}
+		projectIDs = []uuid.UUID{projectID}
 	}
 
 	var status *string
@@ -278,8 +295,32 @@ func ListAllPrompts(c *fiber.Ctx) error {
 		}
 	}
 
+	if queryProvided {
+		searchStatus := model.PromptStatusActive
+		if status != nil {
+			searchStatus = *status
+		} else if archived != nil && *archived {
+			searchStatus = model.PromptStatusArchived
+		}
+
+		ids, err := searcher.Search(c.Context(), search.Request{
+			Text:       query,
+			ProjectIDs: projectIDs,
+			Status:     searchStatus,
+			Limit:      search.DefaultLimit,
+		})
+		if err != nil {
+			return apierr.ErrInternalError.Respond(c, err)
+		}
+		prompts, err := store.GetPromptsByIDs(c.Context(), ids, projectIDs, searchStatus)
+		if err != nil {
+			return apierr.ErrInternalError.Respond(c, err)
+		}
+		return c.JSON(fiber.Map{"prompts": prompts})
+	}
+
 	prompts, err := store.ListPrompts(c.Context(), store.PromptFilter{
-		ProjectIDs: []uuid.UUID{projectID},
+		ProjectIDs: projectIDs,
 		Archived:   archived,
 		Status:     status,
 	})

--- a/internal/handler/prompt_test.go
+++ b/internal/handler/prompt_test.go
@@ -343,6 +343,73 @@ func TestListAllPrompts(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestSearchPromptsAcrossAccessibleProjects(t *testing.T) {
+	a := newTestApp(t)
+	roles := setupProjectRoles(t, a)
+	projectA := uuid.MustParse(createProject(t, a, roles.editorToken, roles.teamID, "Search A"))
+	projectB := uuid.MustParse(createProject(t, a, roles.editorToken, roles.teamID, "Search B"))
+	ctx := context.Background()
+
+	nameMatch, err := store.CreatePrompt(ctx, projectA, "refund_agent", "Refund Assistant", "Handles support")
+	require.NoError(t, err)
+	descriptionMatch, err := store.CreatePrompt(ctx, projectB, "billing_agent", "Billing Assistant", "Explains refund policies")
+	require.NoError(t, err)
+
+	foreignTeam, err := store.CreateTeam(ctx, "Foreign Search Team")
+	require.NoError(t, err)
+	foreignProject, err := store.CreateProject(ctx, foreignTeam.ID, "foreign-search", "Foreign Search")
+	require.NoError(t, err)
+	_, err = store.CreatePrompt(ctx, foreignProject.ID, "private_refund", "Private Refund", "Must not leak")
+	require.NoError(t, err)
+
+	req := newReq(t, http.MethodGet, "/v1/prompts?q=refund", "", roles.viewerToken)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeBody(t, resp)
+	prompts := body["prompts"].([]any)
+	require.Len(t, prompts, 2)
+	assert.Equal(t, nameMatch.ID.String(), prompts[0].(map[string]any)["id"])
+	assert.Equal(t, descriptionMatch.ID.String(), prompts[1].(map[string]any)["id"])
+}
+
+func TestSearchPromptsRejectsEmptyQuery(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+
+	req := newReq(t, http.MethodGet, "/v1/prompts?q=%20%20", "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Equal(t, "q query parameter must not be empty", body["error"])
+}
+
+func TestSearchPromptsExcludesArchivedByDefault(t *testing.T) {
+	a := newTestApp(t)
+	token := setupUser(t, a)
+	projectID := uuid.MustParse(setupProject(t, a, token))
+	ctx := context.Background()
+
+	prompt, err := store.CreatePrompt(ctx, projectID, "refund_archive", "Refund Archive", "")
+	require.NoError(t, err)
+	require.NoError(t, store.ArchivePrompt(ctx, prompt.ID, []uuid.UUID{projectID}))
+
+	req := newReq(t, http.MethodGet, "/v1/prompts?q=refund", "", token)
+	resp, err := a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeBody(t, resp)
+	assert.Empty(t, body["prompts"].([]any))
+
+	req = newReq(t, http.MethodGet, "/v1/prompts?q=refund&archived=true", "", token)
+	resp, err = a.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body = decodeBody(t, resp)
+	assert.Len(t, body["prompts"].([]any), 1)
+}
+
 func TestArchivePrompt_Permissions(t *testing.T) {
 	a := newTestApp(t)
 	ctx := context.Background()

--- a/internal/search/config.go
+++ b/internal/search/config.go
@@ -1,0 +1,55 @@
+package search
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// NewFromEnv builds the two independent retrieval slots. Provider-specific
+// implementations can be added behind these switches without changing the
+// handler, public API, reranker, or authorization contract.
+func NewFromEnv() (*Engine, error) {
+	lexicalName := envOrDefault("SEARCH_FTS_PROVIDER", "postgres")
+	semanticName := envOrDefault("SEARCH_VECTOR_PROVIDER", "none")
+
+	lexical, err := lexicalRetriever(lexicalName)
+	if err != nil {
+		return nil, err
+	}
+	semantic, err := semanticRetriever(semanticName)
+	if err != nil {
+		return nil, err
+	}
+	return NewEngine(lexical, semantic), nil
+}
+
+func lexicalRetriever(name string) (Retriever, error) {
+	switch name {
+	case "postgres":
+		return PostgresRetriever{}, nil
+	case "elasticsearch", "opensearch", "algolia":
+		return nil, fmt.Errorf("FTS search provider %q is configured but not implemented", name)
+	default:
+		return nil, fmt.Errorf("unknown FTS search provider %q", name)
+	}
+}
+
+func semanticRetriever(name string) (Retriever, error) {
+	switch name {
+	case "", "none":
+		return NoopRetriever{}, nil
+	case "qdrant", "pinecone":
+		return nil, fmt.Errorf("vector search provider %q is configured but not implemented", name)
+	default:
+		return nil, fmt.Errorf("unknown vector search provider %q", name)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/search/noop.go
+++ b/internal/search/noop.go
@@ -1,0 +1,10 @@
+package search
+
+import "context"
+
+// NoopRetriever represents an intentionally disabled search slot.
+type NoopRetriever struct{}
+
+func (NoopRetriever) Retrieve(context.Context, Request) ([]Match, error) {
+	return []Match{}, nil
+}

--- a/internal/search/postgres.go
+++ b/internal/search/postgres.go
@@ -1,0 +1,44 @@
+package search
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/px0-ai/px0/internal/db"
+)
+
+// PostgresRetriever provides the default lexical search using PostgreSQL FTS.
+type PostgresRetriever struct{}
+
+func (PostgresRetriever) Retrieve(ctx context.Context, req Request) ([]Match, error) {
+	if req.Text == "" || len(req.ProjectIDs) == 0 {
+		return []Match{}, nil
+	}
+
+	rows, err := db.Pool.Query(ctx, `
+		WITH q AS (SELECT websearch_to_tsquery('english', $1) AS value)
+		SELECT p.id, ts_rank_cd(p.search_vector, q.value) AS score
+		FROM prompts p, q
+		WHERE p.project_id = ANY($2)
+		  AND p.status = $3
+		  AND p.search_vector @@ q.value
+		ORDER BY score DESC, p.updated_at DESC, p.id
+		LIMIT $4`, req.Text, req.ProjectIDs, req.Status, req.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("search prompts with postgres: %w", err)
+	}
+	defer rows.Close()
+
+	matches := make([]Match, 0)
+	for rows.Next() {
+		var match Match
+		if err := rows.Scan(&match.PromptID, &match.Score); err != nil {
+			return nil, fmt.Errorf("scan postgres search result: %w", err)
+		}
+		matches = append(matches, match)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate postgres search results: %w", err)
+	}
+	return matches, nil
+}

--- a/internal/search/postgres_test.go
+++ b/internal/search/postgres_test.go
@@ -1,0 +1,100 @@
+package search_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/px0-ai/px0/internal/model"
+	"github.com/px0-ai/px0/internal/search"
+	"github.com/px0-ai/px0/internal/store"
+	"github.com/px0-ai/px0/internal/testutil"
+)
+
+func TestPostgresRetrieverSearchesFieldsAndEnforcesScope(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+
+	teamA, err := store.CreateTeam(ctx, "Search Team A")
+	require.NoError(t, err)
+	projectA, err := store.CreateProject(ctx, teamA.ID, "search-a", "Search A")
+	require.NoError(t, err)
+	nameMatch, err := store.CreatePrompt(ctx, projectA.ID, "returns", "Refund Assistant", "Handles support")
+	require.NoError(t, err)
+	descriptionMatch, err := store.CreatePrompt(ctx, projectA.ID, "support", "Support Assistant", "Explains refund policies")
+	require.NoError(t, err)
+
+	teamB, err := store.CreateTeam(ctx, "Search Team B")
+	require.NoError(t, err)
+	projectB, err := store.CreateProject(ctx, teamB.ID, "search-b", "Search B")
+	require.NoError(t, err)
+	_, err = store.CreatePrompt(ctx, projectB.ID, "private", "Refund Private", "Must not leak")
+	require.NoError(t, err)
+
+	retriever := search.PostgresRetriever{}
+	matches, err := retriever.Retrieve(ctx, search.Request{
+		Text:       "refund",
+		ProjectIDs: []uuid.UUID{projectA.ID},
+		Status:     model.PromptStatusActive,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, matches, 2)
+	assert.Equal(t, nameMatch.ID, matches[0].PromptID)
+	assert.Equal(t, descriptionMatch.ID, matches[1].PromptID)
+}
+
+func TestPostgresRetrieverExcludesArchivedPrompts(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	team, err := store.CreateTeam(ctx, "Archive Search Team")
+	require.NoError(t, err)
+	project, err := store.CreateProject(ctx, team.ID, "archive-search", "Archive Search")
+	require.NoError(t, err)
+	prompt, err := store.CreatePrompt(ctx, project.ID, "refund", "Refund Assistant", "Handles refunds")
+	require.NoError(t, err)
+	require.NoError(t, store.ArchivePrompt(ctx, prompt.ID, []uuid.UUID{project.ID}))
+
+	matches, err := (search.PostgresRetriever{}).Retrieve(ctx, search.Request{
+		Text:       "refund",
+		ProjectIDs: []uuid.UUID{project.ID},
+		Status:     model.PromptStatusActive,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
+func TestPostgresRetrieverReflectsPromptUpdates(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	team, err := store.CreateTeam(ctx, "Updated Search Team")
+	require.NoError(t, err)
+	project, err := store.CreateProject(ctx, team.ID, "updated-search", "Updated Search")
+	require.NoError(t, err)
+	prompt, err := store.CreatePrompt(ctx, project.ID, "assistant", "Support Assistant", "Handles billing")
+	require.NoError(t, err)
+
+	_, err = store.UpdatePrompt(ctx, prompt.ID, []uuid.UUID{project.ID}, "Handles chargebacks")
+	require.NoError(t, err)
+	retriever := search.PostgresRetriever{}
+	request := search.Request{
+		ProjectIDs: []uuid.UUID{project.ID},
+		Status:     model.PromptStatusActive,
+		Limit:      10,
+	}
+
+	request.Text = "chargebacks"
+	matches, err := retriever.Retrieve(ctx, request)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, prompt.ID, matches[0].PromptID)
+
+	request.Text = "billing"
+	matches, err = retriever.Retrieve(ctx, request)
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,152 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	DefaultLimit = 20
+	rrfConstant  = 60
+)
+
+// Request is the complete, authorization-scoped input supplied to every
+// retriever. Providers must honor ProjectIDs and Status before returning a
+// match; the handler applies the same scope again while hydrating results.
+type Request struct {
+	Text       string
+	ProjectIDs []uuid.UUID
+	Status     string
+	Limit      int
+}
+
+// Match identifies a prompt and its provider-specific relevance score.
+// Retrievers must return matches ordered from most to least relevant.
+type Match struct {
+	PromptID uuid.UUID
+	Score    float64
+}
+
+// Retriever is implemented by lexical and semantic search backends. Keeping
+// the input as natural-language text lets each semantic provider own its
+// embedding strategy instead of exposing vectors through the public API.
+type Retriever interface {
+	Retrieve(context.Context, Request) ([]Match, error)
+}
+
+// Searcher is the handler-facing hybrid search contract.
+type Searcher interface {
+	Search(context.Context, Request) ([]uuid.UUID, error)
+}
+
+// Engine retrieves lexical and semantic candidates concurrently and reranks
+// them with reciprocal-rank fusion, which is stable across incomparable score
+// scales used by different providers.
+type Engine struct {
+	lexical  Retriever
+	semantic Retriever
+}
+
+func NewEngine(lexical, semantic Retriever) *Engine {
+	if lexical == nil {
+		lexical = NoopRetriever{}
+	}
+	if semantic == nil {
+		semantic = NoopRetriever{}
+	}
+	return &Engine{lexical: lexical, semantic: semantic}
+}
+
+func NewDefault() *Engine {
+	return NewEngine(PostgresRetriever{}, NoopRetriever{})
+}
+
+func (e *Engine) Search(ctx context.Context, req Request) ([]uuid.UUID, error) {
+	req.Text = strings.TrimSpace(req.Text)
+	if req.Text == "" || len(req.ProjectIDs) == 0 {
+		return []uuid.UUID{}, nil
+	}
+	if req.Limit <= 0 {
+		req.Limit = DefaultLimit
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type response struct {
+		kind    string
+		matches []Match
+		err     error
+	}
+	responses := make(chan response, 2)
+
+	go func() {
+		matches, err := e.lexical.Retrieve(ctx, req)
+		responses <- response{kind: "lexical", matches: matches, err: err}
+	}()
+	go func() {
+		matches, err := e.semantic.Retrieve(ctx, req)
+		responses <- response{kind: "semantic", matches: matches, err: err}
+	}()
+
+	var lexical, semantic []Match
+	for range 2 {
+		result := <-responses
+		if result.err != nil {
+			return nil, fmt.Errorf("%s retrieval: %w", result.kind, result.err)
+		}
+		if result.kind == "lexical" {
+			lexical = result.matches
+		} else {
+			semantic = result.matches
+		}
+	}
+
+	return fuse(lexical, semantic, req.Limit), nil
+}
+
+type fusedMatch struct {
+	id    uuid.UUID
+	score float64
+}
+
+func fuse(lexical, semantic []Match, limit int) []uuid.UUID {
+	scores := make(map[uuid.UUID]float64)
+
+	for _, matches := range [][]Match{lexical, semantic} {
+		seen := make(map[uuid.UUID]struct{}, len(matches))
+		for rank, match := range matches {
+			if match.PromptID == uuid.Nil {
+				continue
+			}
+			if _, duplicate := seen[match.PromptID]; duplicate {
+				continue
+			}
+			seen[match.PromptID] = struct{}{}
+			scores[match.PromptID] += 1 / float64(rrfConstant+rank+1)
+		}
+	}
+
+	ranked := make([]fusedMatch, 0, len(scores))
+	for id, score := range scores {
+		ranked = append(ranked, fusedMatch{id: id, score: score})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].score == ranked[j].score {
+			return ranked[i].id.String() < ranked[j].id.String()
+		}
+		return ranked[i].score > ranked[j].score
+	})
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+
+	ids := make([]uuid.UUID, len(ranked))
+	for i, match := range ranked {
+		ids[i] = match.id
+	}
+	return ids
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,116 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRetriever struct {
+	mu      sync.Mutex
+	matches []Match
+	err     error
+	calls   []Request
+}
+
+func (f *fakeRetriever) Retrieve(_ context.Context, req Request) ([]Match, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, req)
+	return f.matches, f.err
+}
+
+func (f *fakeRetriever) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func TestEngineSearchRetrievesAndReranksBothSources(t *testing.T) {
+	a := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	b := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	c := uuid.MustParse("00000000-0000-0000-0000-000000000003")
+	projectID := uuid.New()
+	lexical := &fakeRetriever{matches: []Match{{PromptID: a, Score: 0.9}, {PromptID: b, Score: 0.8}}}
+	semantic := &fakeRetriever{matches: []Match{{PromptID: b, Score: 0.7}, {PromptID: c, Score: 0.6}}}
+
+	ids, err := NewEngine(lexical, semantic).Search(context.Background(), Request{
+		Text:       "  refund policy  ",
+		ProjectIDs: []uuid.UUID{projectID},
+		Status:     "active",
+		Limit:      3,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []uuid.UUID{b, a, c}, ids)
+	require.Len(t, lexical.calls, 1)
+	require.Len(t, semantic.calls, 1)
+	assert.Equal(t, "refund policy", lexical.calls[0].Text)
+	assert.Equal(t, []uuid.UUID{projectID}, semantic.calls[0].ProjectIDs)
+}
+
+func TestEngineSearchRejectsRetrieverFailure(t *testing.T) {
+	lexical := &fakeRetriever{err: errors.New("database unavailable")}
+	semantic := &fakeRetriever{}
+
+	_, err := NewEngine(lexical, semantic).Search(context.Background(), Request{
+		Text:       "refund",
+		ProjectIDs: []uuid.UUID{uuid.New()},
+		Status:     "active",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lexical retrieval")
+}
+
+func TestEngineSearchSkipsRetrieversWithoutQueryOrScope(t *testing.T) {
+	lexical := &fakeRetriever{}
+	semantic := &fakeRetriever{}
+	engine := NewEngine(lexical, semantic)
+
+	ids, err := engine.Search(context.Background(), Request{Text: "   ", ProjectIDs: []uuid.UUID{uuid.New()}})
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+
+	ids, err = engine.Search(context.Background(), Request{Text: "refund"})
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+	assert.Zero(t, lexical.callCount())
+	assert.Zero(t, semantic.callCount())
+}
+
+func TestFuseDeduplicatesProviderResultsAndAppliesLimit(t *testing.T) {
+	a := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	b := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+
+	ids := fuse(
+		[]Match{{PromptID: a}, {PromptID: a}, {PromptID: b}, {PromptID: uuid.Nil}},
+		[]Match{{PromptID: b}},
+		1,
+	)
+
+	assert.Equal(t, []uuid.UUID{b}, ids)
+}
+
+func TestNewFromEnvValidatesConfiguredProviders(t *testing.T) {
+	t.Setenv("SEARCH_FTS_PROVIDER", "postgres")
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "none")
+	engine, err := NewFromEnv()
+	require.NoError(t, err)
+	require.NotNil(t, engine)
+
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "qdrant")
+	_, err = NewFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not implemented")
+
+	t.Setenv("SEARCH_VECTOR_PROVIDER", "unknown")
+	_, err = NewFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown vector search provider")
+}

--- a/internal/store/prompt.go
+++ b/internal/store/prompt.go
@@ -92,6 +92,43 @@ func ListPrompts(ctx context.Context, filter PromptFilter) ([]*model.Prompt, err
 	return prompts, rows.Err()
 }
 
+// GetPromptsByIDs hydrates ranked search results while enforcing project and
+// status scope again at the data boundary. The returned order matches ids.
+func GetPromptsByIDs(ctx context.Context, ids, projectIDs []uuid.UUID, status string) ([]*model.Prompt, error) {
+	if len(ids) == 0 || len(projectIDs) == 0 {
+		return []*model.Prompt{}, nil
+	}
+
+	rows, err := db.Pool.Query(ctx, `
+		SELECT id, project_id, slug, name, description, status, created_at, updated_at
+		FROM prompts
+		WHERE id = ANY($1) AND project_id = ANY($2) AND status = $3`, ids, projectIDs, status)
+	if err != nil {
+		return nil, fmt.Errorf("get prompts by ids: %w", err)
+	}
+	defer rows.Close()
+
+	byID := make(map[uuid.UUID]*model.Prompt, len(ids))
+	for rows.Next() {
+		p := &model.Prompt{}
+		if err := rows.Scan(&p.ID, &p.ProjectID, &p.Slug, &p.Name, &p.Description, &p.Status, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan prompt search result: %w", err)
+		}
+		byID[p.ID] = p
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate prompt search results: %w", err)
+	}
+
+	prompts := make([]*model.Prompt, 0, len(byID))
+	for _, id := range ids {
+		if prompt, ok := byID[id]; ok {
+			prompts = append(prompts, prompt)
+		}
+	}
+	return prompts, nil
+}
+
 func GetPromptByID(ctx context.Context, id uuid.UUID, projectIDs []uuid.UUID) (*model.Prompt, error) {
 	p := &model.Prompt{}
 	err := db.Pool.QueryRow(ctx,

--- a/internal/store/prompt_test.go
+++ b/internal/store/prompt_test.go
@@ -84,6 +84,40 @@ func TestListPrompts_Empty(t *testing.T) {
 	assert.Empty(t, prompts)
 }
 
+func TestGetPromptsByIDsPreservesRankAndEnforcesScope(t *testing.T) {
+	testutil.SetupDB(t)
+	ctx := context.Background()
+	project := newProject(t, ctx, "Search")
+	otherProject := newProject(t, ctx, "Private")
+
+	first, err := store.CreatePrompt(ctx, project.ID, "first", "First", "")
+	require.NoError(t, err)
+	second, err := store.CreatePrompt(ctx, project.ID, "second", "Second", "")
+	require.NoError(t, err)
+	private, err := store.CreatePrompt(ctx, otherProject.ID, "private", "Private", "")
+	require.NoError(t, err)
+
+	prompts, err := store.GetPromptsByIDs(ctx,
+		[]uuid.UUID{second.ID, private.ID, first.ID},
+		[]uuid.UUID{project.ID},
+		model.PromptStatusActive,
+	)
+	require.NoError(t, err)
+	require.Len(t, prompts, 2)
+	assert.Equal(t, second.ID, prompts[0].ID)
+	assert.Equal(t, first.ID, prompts[1].ID)
+
+	require.NoError(t, store.ArchivePrompt(ctx, first.ID, []uuid.UUID{project.ID}))
+	prompts, err = store.GetPromptsByIDs(ctx,
+		[]uuid.UUID{first.ID, second.ID},
+		[]uuid.UUID{project.ID},
+		model.PromptStatusActive,
+	)
+	require.NoError(t, err)
+	require.Len(t, prompts, 1)
+	assert.Equal(t, second.ID, prompts[0].ID)
+}
+
 func TestGetPromptByID(t *testing.T) {
 	testutil.SetupDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Add one natural-language prompt search input at `GET /v1/prompts?q=...`.
- Retrieve lexical and semantic candidates concurrently behind small provider interfaces.
- Rerank candidates with deterministic reciprocal-rank fusion.
- Enforce project access both during retrieval and while hydrating results.
- Use weighted PostgreSQL full-text search as the default lexical provider.

Closes #9.

## Why

Prompt search should not expose storage or embedding details to API consumers. Callers should submit plain English and receive the most relevant prompts they are allowed to view, regardless of which lexical or vector backends are configured internally.

This keeps the public contract stable while allowing PostgreSQL FTS, Elasticsearch, OpenSearch, Algolia, Qdrant, Pinecone, or future providers to be added without changing handlers or clients.

## Implementation

### One public search contract

`GET /v1/prompts?q=<natural-language text>` searches across every project the authenticated subject can view. Existing non-search behavior and optional project filtering remain backward compatible.

The API does not accept raw vectors, search modes, provider names, or provider-specific scores. Empty and whitespace-only queries return `400`.

### Hybrid retrieval and reranking

The search engine invokes lexical and semantic retrievers concurrently with the same query, project scope, status, and result limit. It combines the ordered candidate lists with reciprocal-rank fusion, avoiding assumptions about incompatible score scales between providers.

PostgreSQL FTS indexes prompt name, description, and slug with descending field weights. A generated `tsvector` column and GIN index keep the search document synchronized automatically when prompts change.

### RBAC and data isolation

Authorized project IDs are resolved before retrieval and passed to every provider. Ranked IDs are then hydrated through a second project-and-status-scoped store query, preserving rank order while preventing an external or faulty provider from leaking inaccessible prompts.

The same behavior applies to user sessions and scoped API keys, including project access grants and revocations.

### Provider configuration

`SEARCH_FTS_PROVIDER` and `SEARCH_VECTOR_PROVIDER` configure independent retrieval slots. PostgreSQL is the default FTS provider; vector retrieval is disabled by default. Configuration keys for Elasticsearch, OpenSearch, Algolia, Qdrant, and Pinecone are documented in `.env.example`, and unsupported selections fail explicitly at startup instead of silently changing search behavior.

## API and documentation

- Update `docs/openapi/prompts.yaml` with the natural-language query contract, authorization boundaries, edge cases, and test coverage.
- Regenerate `docs/openapi/openapi-bundled.yaml`.
- Preserve the existing response shape: `{ "prompts": [...] }`.

## Validation

- `make spec-bundle`
- `make test`
- `go vet ./...`
- `golangci-lint run --new-from-rev=upstream/master`
- `git diff --check`

The full race-enabled unit and integration suite passes, including regression coverage for weighted FTS, prompt updates, archived status, cross-project search, inaccessible-project isolation, API-key grants and revocations, provider failures, duplicate candidates, deterministic reranking, and empty queries.

Repository-wide `make check` is currently blocked at its lint step by pre-existing findings on `upstream/master`; this branch introduces no new lint findings.
